### PR TITLE
Split the Postgres prep

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -73,7 +73,8 @@ COPY assets/redis.run /etc/services.d/redis/run
 COPY assets/pulpcore-worker@2.run /etc/services.d/pulpcore-worker@2/run
 COPY assets/pulpcore-resource-manager.run /etc/services.d/pulpcore-resource-manager/run
 COPY assets/pulpcore-api.run /etc/services.d/pulpcore-api/run
-COPY assets/postgres.prep /etc/cont-init.d/postgres
+COPY assets/000-postgres.prep /etc/cont-init.d/000-postgres
+COPY assets/zzz-postgres.prep /etc/cont-init.d/zzz-postgres
 COPY assets/pulpcore-worker@1.run /etc/services.d/pulpcore-worker@1/run
 COPY assets/nginx.conf /etc/nginx/nginx.conf
 COPY assets/nginx.run /etc/services.d/nginx/run

--- a/assets/000-postgres.prep
+++ b/assets/000-postgres.prep
@@ -105,11 +105,3 @@ foreground {
   s6-setuidgid postgres
   /usr/local/bin/django-admin migrate
 }
-
-foreground {
-  if { s6-echo "${PREFFIX} ${C133}shutdown service [${PG_PID}] postgres${C000}" }
-  redirfd -w 1 /dev/null
-  fdmove -c 2 1
-  s6-setuidgid postgres
-  pg_ctl -D ${PGDATA} stop
-}

--- a/assets/zzz-postgres.prep
+++ b/assets/zzz-postgres.prep
@@ -1,0 +1,37 @@
+#!/usr/bin/execlineb -S0
+
+backtick -n BASENAME { s6-basename ${0} }
+importas -u BASENAME BASENAME
+define PREFFIX "[cont-init.d] ${BASENAME}:"
+
+define C000 "\033[0m"
+define C030 "\033[0;30m"
+define C031 "\033[0;31m"
+define C032 "\033[0;32m"
+define C033 "\033[0;33m"
+define C034 "\033[0;34m"
+define C035 "\033[0;35m"
+define C036 "\033[0;36m"
+define C037 "\033[0;37m"
+define C130 "\033[1;30m"
+define C131 "\033[1;31m"
+define C132 "\033[1;32m"
+define C133 "\033[1;33m"
+define C134 "\033[1;34m"
+define C135 "\033[1;35m"
+define C136 "\033[1;36m"
+define C137 "\033[1;37m"
+
+backtick -n ! { pipeline { postgres --version } egrep -o "[0-9]{1,}\.[0-9]{1,}" }
+importas -u PGVERSION !
+define PGHOME "/var/lib/pgsql"
+define PGDATA "${PGHOME}/data"
+
+foreground {
+  if { s6-echo "${PREFFIX} ${C133}shutdown service [${PG_PID}] postgres${C000}" }
+  redirfd -w 1 /dev/null
+  fdmove -c 2 1
+  s6-setuidgid postgres
+  pg_ctl -D ${PGDATA} stop
+}
+


### PR DESCRIPTION
This allows downstream builds to use the image as a base and add script
files to /etc/cont-init.d/ that manipulate the database (like setting
the admin's password) without having to do resort to terrible tricks to
modify the prep file.

[noissue]