### PR TITLE
Change the way the version args work

### DIFF
--- a/.github/workflows/pr_build_images.yaml
+++ b/.github/workflows/pr_build_images.yaml
@@ -14,3 +14,14 @@ jobs:
           docker build --file pulp_ci/Containerfile --tag pulp/pulp-ci:latest .
           docker build --file pulp_fedora31/Containerfile --tag pulp/pulp-fedora31:latest .
           docker build --file pulp_galaxy_ng/Containerfile --tag pulp/pulp-galaxy-ng:latest .
+      - name: Test the images
+        run: |
+          mkdir settings
+          echo "CONTENT_ORIGIN='http://$(hostname):8080'" >> settings/settings.py
+          docker run --detach \
+                     --publish 8080:80 \
+                     --volume "/$(pwd)/settings:/etc/pulp:Z" \
+                     --device /dev/fuse \
+                     pulp/pulp-fedora31:latest
+          sleep 30
+          curl --fail localhost:8080/pulp/api/v3/status/

--- a/README.md
+++ b/README.md
@@ -12,3 +12,13 @@ $ <docker build | buildah bud> --file pulp_ci/Containerfile --tag pulp/pulp-ci:l
 $ <docker build | buildah bud> --file pulp_fedora31/Containerfile --tag pulp/pulp-fedora31:latest .
 $ <docker build | buildah bud> --file pulp_galaxy_ng/Containerfile --tag pulp/pulp-galaxy-ng:latest .
 ```
+
+## Specifying versions
+
+By default, containers get built using the latest version of each Pulp component. If you want to
+specify a version of a particular component, you can do so with args:
+
+```bash
+$ <docker build | buildah bud> --build_arg PULPCORE_VERSION="==3.5.0" --file pulp_fedora31/Containerfile
+$ <docker build | buildah bud> --build_arg PULP_FILE_VERSION=">=1.0.0" --file pulp_fedora31/Containerfile
+```

--- a/pulp_fedora31/Containerfile
+++ b/pulp_fedora31/Containerfile
@@ -1,20 +1,20 @@
 FROM pulp/pulp-ci:latest
 
-ARG PULPCORE_VERSION=3.6.0
-ARG PULP_FILE_VERSION=1.2.0
-ARG PULP_CONTAINER_VERSION=2.0.0
-ARG PULP_ANSIBLE_VERSION=0.2.0
-ARG PULP_RPM_VERSION=3.6.1
-ARG PULP_MAVEN_VERSION=0.1.0
+ARG PULPCORE_VERSION=""
+ARG PULP_FILE_VERSION=""
+ARG PULP_CONTAINER_VERSION=""
+ARG PULP_ANSIBLE_VERSION=""
+ARG PULP_RPM_VERSION=""
+ARG PULP_MAVEN_VERSION=""
 
 RUN pip3 install --upgrade --use-feature=2020-resolver \
   requests \
-  pulpcore==${PULPCORE_VERSION} \
-  pulp-file==${PULP_FILE_VERSION} \
-  pulp-container==${PULP_CONTAINER_VERSION} \
-  pulp-ansible==${PULP_ANSIBLE_VERSION} \
-  pulp-rpm==${PULP_RPM_VERSION} \
-  pulp-maven==${PULP_MAVEN_VERSION}
+  pulpcore${PULPCORE_VERSION} \
+  pulp-file${PULP_FILE_VERSION} \
+  pulp-container${PULP_CONTAINER_VERSION} \
+  pulp-ansible${PULP_ANSIBLE_VERSION} \
+  pulp-rpm${PULP_RPM_VERSION} \
+  pulp-maven${PULP_MAVEN_VERSION}
 
 RUN ln /usr/local/lib/python3.7/site-packages/pulp_ansible/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_ansible.conf
 RUN ln /usr/local/lib/python3.7/site-packages/pulp_container/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_container.conf

--- a/pulp_galaxy_ng/Containerfile
+++ b/pulp_galaxy_ng/Containerfile
@@ -1,16 +1,16 @@
 FROM pulp/pulp-ci:latest
 
-ARG PULPCORE_VERSION=3.4.1
-ARG PULP_CONTAINER_VERSION=2.0.0b2
-ARG PULP_ANSIBLE_VERSION=0.2.0b13
-ARG GALAXY_NG_VERSION=4.2.0a8
+ARG PULPCORE_VERSION="==3.4.1"
+ARG PULP_CONTAINER_VERSION="==2.0.0b2"
+ARG PULP_ANSIBLE_VERSION="==0.2.0b13"
+ARG GALAXY_NG_VERSION="==4.2.0a8"
 
 RUN pip3 install --upgrade --use-feature=2020-resolver \
   requests \
-  pulpcore==${PULPCORE_VERSION} \
-  pulp-container==${PULP_CONTAINER_VERSION} \
-  pulp-ansible==${PULP_ANSIBLE_VERSION} \
-  galaxy-ng==${GALAXY_NG_VERSION}
+  pulpcore${PULPCORE_VERSION} \
+  pulp-container${PULP_CONTAINER_VERSION} \
+  pulp-ansible${PULP_ANSIBLE_VERSION} \
+  galaxy-ng${GALAXY_NG_VERSION}
 
 RUN ln /usr/local/lib/python3.7/site-packages/pulp_ansible/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_ansible.conf
 RUN ln /usr/local/lib/python3.7/site-packages/pulp_container/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_container.conf


### PR DESCRIPTION
Allow users to specify an operator and default to nothing when building
pulp-oci-images container.

fixes #6955