### PR TITLE
Fix the galaxy_ng image name for the publish step

### DIFF
--- a/.github/workflows/publish_images.yaml
+++ b/.github/workflows/publish_images.yaml
@@ -28,4 +28,4 @@ jobs:
         run: |
           docker push docker.io/pulp/pulp-ci:latest
           docker push docker.io/pulp/pulp-fedora31:latest
-          docker push docker.io/pulp/pulp-galaxy_ng:latest
+          docker push docker.io/pulp/pulp-galaxy-ng:latest


### PR DESCRIPTION
@mdellweg Looks like the publish step for the pulp-galaxy-ng image failed.  This fix should address the issue.  Not sure how you want to handle this, so figured I'd just throw a quick PR together.

[noissue]