### PR TITLE
Expose pulp API for CI usage

### DIFF
--- a/assets/pulpcore-api.run
+++ b/assets/pulpcore-api.run
@@ -6,4 +6,4 @@ foreground {
 }
 export DJANGO_SETTINGS_MODULE pulpcore.app.settings
 export PULP_SETTINGS /etc/pulp/settings.py
-/usr/local/bin/gunicorn pulpcore.app.wsgi:application --bind "127.0.0.1:24817" --access-logfile -
+/usr/local/bin/gunicorn pulpcore.app.wsgi:application --bind "0.0.0.0:24817" --access-logfile -

--- a/pulp_ci/Containerfile
+++ b/pulp_ci/Containerfile
@@ -95,4 +95,4 @@ COPY assets/nginx.run /etc/services.d/nginx/run
 
 ENTRYPOINT ["/init"]
 
-EXPOSE 80
+EXPOSE 80 24817

--- a/pulp_ci/Containerfile
+++ b/pulp_ci/Containerfile
@@ -95,4 +95,4 @@ COPY assets/nginx.run /etc/services.d/nginx/run
 
 ENTRYPOINT ["/init"]
 
-EXPOSE 80 24817
+EXPOSE 80


### PR DESCRIPTION
The change introduced in https://github.com/ansible/galaxy_ng/pull/495 denies access to the internal pulp API through the nginx proxy. This makes sure that the pulp API hosted by gunicorn is can be exposed through port 24817 for users who need to access this API. I'm not sure if this is a security concern but this is the first blocker for Ansible updating the pulp container used in it's CI testing as it needs to manage distributions dynamically.