### PR TITLE
Skip building galaxy-ng when pulpcore release is specified

### DIFF
--- a/.github/workflows/publish_images.yaml
+++ b/.github/workflows/publish_images.yaml
@@ -32,7 +32,6 @@ jobs:
           else
             version_req="$version.0"
             docker build --file pulp_fedora31/Containerfile --tag pulp/pulp-fedora31:$version --build-arg PULPCORE_VERSION="~=$version_req" .
-            docker build --file pulp_galaxy_ng/Containerfile --tag pulp/pulp-galaxy-ng:$version --build-arg PULPCORE_VERSION="~=$version_req" .
           fi
       - name: Docker login
         env:
@@ -45,6 +44,6 @@ jobs:
           if [ -z "$version" ]; then
             version="latest"
             docker push docker.io/pulp/pulp-ci:latest
+            docker push docker.io/pulp/pulp-galaxy-ng:latest
           fi
           docker push docker.io/pulp/pulp-fedora31:$version
-          docker push docker.io/pulp/pulp-galaxy-ng:$version


### PR DESCRIPTION
The pulp-galaxy-ng Containerfile uses specific version dependencies and can't be built against just any pulpcore release.

Eventually, I'm hoping to have a separate input for the galaxy_ng image but for now, just skip building it.

[noissue]