### PR TITLE
Silence 2020-resolver warnings

### DIFF
--- a/pulp_fedora31/Containerfile
+++ b/pulp_fedora31/Containerfile
@@ -9,7 +9,7 @@ ARG PULP_FILE_VERSION=""
 ARG PULP_MAVEN_VERSION=""
 ARG PULP_RPM_VERSION=""
 
-RUN pip3 install --upgrade --use-feature=2020-resolver \
+RUN pip3 install --upgrade \
   pulpcore${PULPCORE_VERSION} \
   pulp-ansible${PULP_ANSIBLE_VERSION} \
   pulp-certguard${PULP_CERTGUARD_VERSION} \

--- a/pulp_galaxy_ng/Containerfile
+++ b/pulp_galaxy_ng/Containerfile
@@ -5,7 +5,7 @@ ARG PULP_CONTAINER_VERSION="==2.1.0"
 ARG PULP_ANSIBLE_VERSION="==0.5.0"
 ARG GALAXY_NG_VERSION="==4.2.0rc2"
 
-RUN pip3 install --upgrade --use-feature=2020-resolver \
+RUN pip3 install --upgrade \
   requests \
   pulpcore${PULPCORE_VERSION} \
   pulp-container${PULP_CONTAINER_VERSION} \


### PR DESCRIPTION
```
WARNING: --use-feature=2020-resolver no longer has any effect, since it is now the default dependency resolver in pip. This will become an error in pip 21.0.
```

[noissue]