### PR TITLE
Initial data for Galaxy

### DIFF
--- a/pulp_galaxy_ng/README.md
+++ b/pulp_galaxy_ng/README.md
@@ -1,0 +1,8 @@
+# Galaxy
+
+For loading the initial data:
+```bash
+$ DATA_FIXTURE_URL="https://raw.githubusercontent.com/ansible/galaxy_ng/master/dev/automation-hub/initial_data.json"
+$ curl $DATA_FIXTURE_URL | <docker | podman> exec -i pulp bash -c "cat > /tmp/initial_data.json"
+$ <docker | podman> exec pulp bash -c "/usr/local/bin/pulpcore-manager loaddata /tmp/initial_data.json"
+```


### PR DESCRIPTION
This adds initial data for Galaxy:
```
[cont-init.d] pulp-galaxy-api: executing... 
Installed 21 object(s) from 1 fixture(s)
```
I'm wondering if we should trigger this as default, or just add the fixture to a path and the user runs:
```
/usr/local/bin/pulpcore-manager loaddata /etc/pulp-galaxy/initial_data.json
```