### PR TITLE
Ensure we clean the static folder before running collectstatic.

### DIFF
--- a/assets/pulpcore-api.run
+++ b/assets/pulpcore-api.run
@@ -2,7 +2,7 @@
 foreground {
   export DJANGO_SETTINGS_MODULE pulpcore.app.settings
   export PULP_CONTENT_ORIGIN localhost
-  /usr/local/bin/pulpcore-manager collectstatic --noinput --link
+  /usr/local/bin/pulpcore-manager collectstatic --clear --noinput --link
 }
 export DJANGO_SETTINGS_MODULE pulpcore.app.settings
 export PULP_SETTINGS /etc/pulp/settings.py


### PR DESCRIPTION
This prevents some upgrade issues.

fixes: https://github.com/pulp/pulp-oci-images/issues/77