### PR TITLE
Use new worker entrypoint

### DIFF
--- a/assets/new-pulpcore-resource-manager.run
+++ b/assets/new-pulpcore-resource-manager.run
@@ -1,0 +1,5 @@
+#!/usr/bin/execlineb -P
+export DJANGO_SETTINGS_MODULE pulpcore.app.settings
+export PULP_SETTINGS /etc/pulp/settings.py
+export PATH /usr/local/bin:/usr/bin/
+/usr/local/bin/pulpcore-worker --resource-manager

--- a/assets/pulpcore-worker.prep
+++ b/assets/pulpcore-worker.prep
@@ -9,7 +9,8 @@ ifte
 }
 {
   touch
+    /etc/services.d/new-pulpcore-resource-manager/down
     /etc/services.d/new-pulpcore-worker@1/down
     /etc/services.d/new-pulpcore-worker@2/down
 }
-grep -q -e "USE_NEW_WORKER_TYPE\\s*=\\s*True" /etc/pulp/settings.py
+python3 -c "import sys; from packaging.version import parse; from pulpcore.app.apps import PulpAppConfig; sys.exit(0 if parse(PulpAppConfig.version) >= parse('3.13.0.dev0') else 1)"

--- a/pulp_ci_centos/Containerfile
+++ b/pulp_ci_centos/Containerfile
@@ -61,6 +61,7 @@ RUN mkdir -p /etc/nginx/pulp \
              /etc/services.d/pulpcore-resource-manager \
              /etc/services.d/pulpcore-worker@1 \
              /etc/services.d/pulpcore-worker@2 \
+             /etc/services.d/new-pulpcore-resource-manager \
              /etc/services.d/new-pulpcore-worker@1 \
              /etc/services.d/new-pulpcore-worker@2 \
              /etc/services.d/redis \


### PR DESCRIPTION
To still support versions prior to 3.13, keep the old startup scripts around.