### PR TITLE
Fix missing new-pulpcore-resource-manager/run

### DIFF
--- a/pulp_ci_centos/Containerfile
+++ b/pulp_ci_centos/Containerfile
@@ -83,6 +83,7 @@ COPY assets/postgres.run /etc/services.d/postgresql/run
 COPY assets/redis.run /etc/services.d/redis/run
 COPY assets/pulpcore-worker.prep /etc/cont-init.d/pulpcore-worker
 COPY assets/pulpcore-resource-manager.run /etc/services.d/pulpcore-resource-manager/run
+COPY assets/new-pulpcore-resource-manager.run /etc/services.d/new-pulpcore-resource-manager/run
 COPY assets/pulpcore-worker@1.run /etc/services.d/pulpcore-worker@1/run
 COPY assets/pulpcore-worker@2.run /etc/services.d/pulpcore-worker@2/run
 COPY assets/new-pulpcore-worker@1.run /etc/services.d/new-pulpcore-worker@1/run


### PR DESCRIPTION
The service file for the resource-manager with the new entry point was
missing.

[noissue]