### PR TITLE
Attempt to fix psycopg2 2.9.1 missing dep

### DIFF
--- a/pulp_ci_centos/Containerfile
+++ b/pulp_ci_centos/Containerfile
@@ -38,6 +38,7 @@ RUN dnf -y install dnf-plugins-core && \
     dnf -y install postgresql && \
     dnf -y install postgresql-contrib && \
     dnf -y install postgresql-server && \
+    dnf -y install libpq-devel && \
     dnf -y install nginx && \
     dnf -y install redis && \
     dnf -y install python3-setuptools && \


### PR DESCRIPTION
Error:

```
        Collecting psycopg2~=2.9.1
          Downloading psycopg2-2.9.1.tar.gz (379 kB)
            Complete output (23 lines):
            running egg_info
            creating /tmp/pip-pip-egg-info-74g4atzi/psycopg2.egg-info
            writing /tmp/pip-pip-egg-info-74g4atzi/psycopg2.egg-info/PKG-INFO
            writing dependency_links to /tmp/pip-pip-egg-info-74g4atzi/psycopg2.egg-info/dependency_links.txt
            writing top-level names to /tmp/pip-pip-egg-info-74g4atzi/psycopg2.egg-info/top_level.txt
            writing manifest file '/tmp/pip-pip-egg-info-74g4atzi/psycopg2.egg-info/SOURCES.txt'
    
            Error: pg_config executable not found.
    
            pg_config is required to build psycopg2 from source.  Please add the directory
            containing pg_config to the $PATH or specify the full executable path with the
            option:
    
                python setup.py build_ext --pg-config /path/to/pg_config build ...
    
            or with the pg_config option in 'setup.cfg'.
    
            If you prefer to avoid building psycopg2 from source, please install the PyPI
            'psycopg2-binary' package instead.
    
            For further information please check the 'doc/src/install.rst' file (also at
            <https://www.psycopg.org/docs/install.html>).
    
            ----------------------------------------
```