### PR TITLE
Install packaging package

### DIFF
--- a/pulp_ci_centos/Containerfile
+++ b/pulp_ci_centos/Containerfile
@@ -80,7 +80,7 @@ RUN mkdir -p /etc/nginx/pulp \
              /var/run/new-pulpcore-worker-1 \
              /var/run/new-pulpcore-worker-2
 
-RUN pip3 install --upgrade pip
+RUN pip3 install --upgrade pip packaging
 
 RUN echo "/var/lib/pgsql true postgres 0600 0750" >> /etc/fix-attrs.d/postgres
 


### PR DESCRIPTION
It's required by the pulp worker prep file:

https://github.com/pulp/pulp-oci-images/blob/33264a925d2c7e0afcad4ed9283a21978832ae89/assets/pulpcore-worker.prep#L16

[noissue]
