### PR TITLE
Fix image test

### DIFF
--- a/assets/test.sh
+++ b/assets/test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -eu
+set -euo pipefail
 
 cleanup() {
   echo ::group::INFO


### PR DESCRIPTION
jq was suppressing the error

```
pulp-oci-images on  latest [⇡$] via 🐍 v3.9.1 (venv) 
❯ curl www.fao.br  
curl: (6) Could not resolve host: www.fao.br
pulp-oci-images on  latest [⇡$] via 🐍 v3.9.1 (venv) 
❯ echo $?                  
6
```

```
pulp-oci-images on  latest [⇡$] via 🐍 v3.9.1 (venv) 
❯ curl www.fao.br | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: www.fao.br
pulp-oci-images on  latest [⇡$] via 🐍 v3.9.1 (venv) 
❯ echo $?             
0
```