### PR TITLE
Change client_max_body_size to 1024m

### DIFF
--- a/assets/nginx.conf
+++ b/assets/nginx.conf
@@ -59,7 +59,7 @@ http {
             # redirects, we set the Host: header above already.
             proxy_redirect off;
             proxy_pass http://pulp-api;
-            client_max_body_size 1024m;
+            client_max_body_size 0;
         }
 
         location /auth/login/ {

--- a/assets/nginx.conf
+++ b/assets/nginx.conf
@@ -59,7 +59,7 @@ http {
             # redirects, we set the Host: header above already.
             proxy_redirect off;
             proxy_pass http://pulp-api;
-            client_max_body_size 10m;
+            client_max_body_size 1024m;
         }
 
         location /auth/login/ {


### PR DESCRIPTION
Current limit - 10m doesn't allow to upload bigger RPM artifacts.