### PR TITLE
Removes resource manager from single container

### DIFF
--- a/assets/new-pulpcore-resource-manager.run
+++ b/assets/new-pulpcore-resource-manager.run
@@ -1,5 +1,0 @@
-#!/usr/bin/execlineb -P
-export DJANGO_SETTINGS_MODULE pulpcore.app.settings
-export PULP_SETTINGS /etc/pulp/settings.py
-export PATH /usr/local/bin:/usr/bin/
-/usr/local/bin/pulpcore-worker --resource-manager

--- a/assets/pulpcore-resource-manager.run
+++ b/assets/pulpcore-resource-manager.run
@@ -1,4 +1,0 @@
-#!/usr/bin/execlineb -P
-export DJANGO_SETTINGS_MODULE pulpcore.app.settings
-export PULP_SETTINGS /etc/pulp/settings.py
-/usr/local/bin/rq worker -w pulpcore.tasking.worker.PulpWorker -n resource-manager --pid=/var/run/pulpcore-resource-manager/resource-manager.pid -c "pulpcore.rqconfig" --disable-job-desc-logging

--- a/assets/pulpcore-worker.prep
+++ b/assets/pulpcore-worker.prep
@@ -3,13 +3,11 @@
 ifte
 {
   touch
-    /etc/services.d/pulpcore-resource-manager/down
     /etc/services.d/pulpcore-worker@1/down
     /etc/services.d/pulpcore-worker@2/down
 }
 {
   touch
-    /etc/services.d/new-pulpcore-resource-manager/down
     /etc/services.d/new-pulpcore-worker@1/down
     /etc/services.d/new-pulpcore-worker@2/down
 }

--- a/pulp_ci_centos/Containerfile
+++ b/pulp_ci_centos/Containerfile
@@ -69,10 +69,8 @@ RUN mkdir -p /etc/nginx/pulp \
              /etc/services.d/postgresql \
              /etc/services.d/pulpcore-api \
              /etc/services.d/pulpcore-content \
-             /etc/services.d/pulpcore-resource-manager \
              /etc/services.d/pulpcore-worker@1 \
              /etc/services.d/pulpcore-worker@2 \
-             /etc/services.d/new-pulpcore-resource-manager \
              /etc/services.d/new-pulpcore-worker@1 \
              /etc/services.d/new-pulpcore-worker@2 \
              /etc/services.d/redis \
@@ -81,7 +79,6 @@ RUN mkdir -p /etc/nginx/pulp \
              /var/lib/pgsql \
              /var/lib/pulp/assets \
              /var/lib/pulp/media \
-             /var/run/pulpcore-resource-manager \
              /var/run/pulpcore-worker-1 \
              /var/run/pulpcore-worker-2 \
              /var/run/new-pulpcore-worker-1 \
@@ -97,8 +94,6 @@ COPY assets/pulpcore-content.run /etc/services.d/pulpcore-content/run
 COPY assets/postgres.run /etc/services.d/postgresql/run
 COPY assets/redis.run /etc/services.d/redis/run
 COPY assets/pulpcore-worker.prep /etc/cont-init.d/pulpcore-worker
-COPY assets/pulpcore-resource-manager.run /etc/services.d/pulpcore-resource-manager/run
-COPY assets/new-pulpcore-resource-manager.run /etc/services.d/new-pulpcore-resource-manager/run
 COPY assets/pulpcore-worker@1.run /etc/services.d/pulpcore-worker@1/run
 COPY assets/pulpcore-worker@2.run /etc/services.d/pulpcore-worker@2/run
 COPY assets/new-pulpcore-worker@1.run /etc/services.d/new-pulpcore-worker@1/run


### PR DESCRIPTION
The resource manager no longer able to be run in the upcoming version of
Pulp.