### PR TITLE
Adding containerfile for pulp with debuginfod

### DIFF
--- a/pulp_debuginfod/Containerfile
+++ b/pulp_debuginfod/Containerfile
@@ -1,0 +1,41 @@
+ARG FROM_TAG="latest"
+FROM pulp/pulp-ci-centos:${FROM_TAG}
+
+ARG PULPCORE_VERSION=""
+ARG PULP_ANSIBLE_VERSION=""
+ARG PULP_CERTGUARD_VERSION=""
+ARG PULP_CONTAINER_VERSION=""
+ARG PULP_DEB_VERSION=""
+ARG PULP_FILE_VERSION=""
+ARG PULP_MAVEN_VERSION=""
+ARG PULP_PYTHON_VERSION=""
+ARG PULP_RPM_VERSION=""
+ARG PULP_CLI_VERSION=""
+# Additional debuginfod arguments such as -d DATABASE or -t SECONDS. See man debuginfod for the full argument list
+ARG DEBUGINFOD_OPTIONS=""
+
+RUN pip3 install --upgrade \
+  pulpcore${PULPCORE_VERSION} \
+  pulp-ansible${PULP_ANSIBLE_VERSION} \
+  pulp-certguard${PULP_CERTGUARD_VERSION} \
+  pulp-container${PULP_CONTAINER_VERSION} \
+  pulp-deb${PULP_DEB_VERSION} \
+  pulp-file${PULP_FILE_VERSION} \
+  pulp-maven${PULP_MAVEN_VERSION} \
+  pulp-python${PULP_PYTHON_VERSION} \
+  pulp-rpm${PULP_RPM_VERSION} \
+  pulp-cli${PULP_CLI_VERSION} \
+  requests
+
+RUN ln /usr/local/lib/python3.8/site-packages/pulp_ansible/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_ansible.conf
+RUN ln /usr/local/lib/python3.8/site-packages/pulp_container/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_container.conf
+RUN ln /usr/local/lib/python3.8/site-packages/pulp_python/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_python.conf
+
+# Install debuginfod and run as a background process
+RUN dnf -y install elfutils-debuginfod
+# You cannot start background processes in a Dockerfile directly (everything is stopped at the end of each RUN command)
+# So start debuginfod in a shell script before continuing the default starting script
+RUN echo '#!/bin/bash' > start_script.sh
+RUN echo "debuginfod -R /var/lib/pulp -Z=cat $DEBUGINFOD_OPTIONS & /init" >> start_script.sh
+RUN chmod +x start_script.sh
+ENTRYPOINT ["./start_script.sh"]

--- a/pulp_debuginfod/README
+++ b/pulp_debuginfod/README
@@ -1,0 +1,1 @@
+This container is the same as in pulp/Containerfile but with a debuginfod server running in the background


### PR DESCRIPTION
Added in containerfile which starts up [debuginfod](https://sourceware.org/elfutils/Debuginfod.html) server as background process. Makes it easy for debugger-like tools, such as valgrind and gdb, run both in and out of the container to access packages managed by pulp-rpm.

Here is a brief video demo: https://drive.google.com/file/d/1QN6yLULSZNyO_5CFvp1xEeIbN-ejrVnx/view?usp=sharing
- Unfortunately I can only share that link with Red hat emails, but feel free to reach out to me and I can share it with you

I'm not sure if you guys are interested in something like this, but thought I'd offer it up. 