### PR TITLE
Install podman and sudo in the pulp_ci_centos image.

### DIFF
--- a/pulp_ci_centos/Containerfile
+++ b/pulp_ci_centos/Containerfile
@@ -49,6 +49,8 @@ RUN dnf -y install dnf-plugins-core && \
     dnf -y install ninja-build && \
     dnf -y install 'dnf-command(builddep)' && \
     dnf -y builddep createrepo_c && \
+    dnf -y install podman && \
+    dnf -y install sudo && \
     dnf clean all
 
 RUN sed 's|^#mount_program|mount_program|g' -i /etc/containers/storage.conf


### PR DESCRIPTION
When running pulp_container functional tests inside the container, podman is needed.

When running pulp_rpm functional tests inside the container, sudo is needed so tests
don't have to differentiate between running inside a VM or a container.

closes: #202