### PR TITLE
Exit with code 0 instead of 1 in pulpcore-api init script

### DIFF
--- a/assets/init/pulpcore-api
+++ b/assets/init/pulpcore-api
@@ -6,7 +6,7 @@ foreground {
   }
   mkdir -p /etc/pulp/certs
 }
-if -n {
+if -n -x 0 {
   ls /etc/pulp/certs/token_private_key.pem
 }
 foreground {


### PR DESCRIPTION
This will make it so that the containers can be run with `S6_BEHAVIOUR_IF_STAGE2_FAILS=2`, which will cause them to shutdown if there is an error in any of the startup scripts.

Required to fix https://github.com/pulp/oci_env/issues/19