### PR TITLE
Update s6-overaly from 3.1.2.0 to 3.1.2.1

### DIFF
--- a/.github/workflows/pr_build_images.yaml
+++ b/.github/workflows/pr_build_images.yaml
@@ -27,10 +27,10 @@ jobs:
       - uses: actions/checkout@v2
       - name: Build the images
         run: |
-          wget https://github.com/just-containers/s6-overlay/releases/download/v3.1.2.0/s6-overlay-x86_64.tar.xz
-          wget https://github.com/just-containers/s6-overlay/releases/download/v3.1.2.0/s6-overlay-noarch.tar.xz
-          wget https://github.com/just-containers/s6-overlay/releases/download/v3.1.2.0/s6-overlay-symlinks-arch.tar.xz
-          wget https://github.com/just-containers/s6-overlay/releases/download/v3.1.2.0/s6-overlay-symlinks-noarch.tar.xz
+          wget https://github.com/just-containers/s6-overlay/releases/download/v3.1.2.1/s6-overlay-x86_64.tar.xz
+          wget https://github.com/just-containers/s6-overlay/releases/download/v3.1.2.1/s6-overlay-noarch.tar.xz
+          wget https://github.com/just-containers/s6-overlay/releases/download/v3.1.2.1/s6-overlay-symlinks-arch.tar.xz
+          wget https://github.com/just-containers/s6-overlay/releases/download/v3.1.2.1/s6-overlay-symlinks-noarch.tar.xz
           unxz s6-overlay*.tar.xz
           gzip s6-overlay*.tar
           docker build --file ${{ matrix.ci_type }}/Containerfile --tag pulp/${{ matrix.ci_image }}:latest .
@@ -59,10 +59,10 @@ jobs:
       - uses: actions/checkout@v2
       - name: Build the images
         run: |
-          wget https://github.com/just-containers/s6-overlay/releases/download/v3.1.2.0/s6-overlay-x86_64.tar.xz
-          wget https://github.com/just-containers/s6-overlay/releases/download/v3.1.2.0/s6-overlay-noarch.tar.xz
-          wget https://github.com/just-containers/s6-overlay/releases/download/v3.1.2.0/s6-overlay-symlinks-arch.tar.xz
-          wget https://github.com/just-containers/s6-overlay/releases/download/v3.1.2.0/s6-overlay-symlinks-noarch.tar.xz
+          wget https://github.com/just-containers/s6-overlay/releases/download/v3.1.2.1/s6-overlay-x86_64.tar.xz
+          wget https://github.com/just-containers/s6-overlay/releases/download/v3.1.2.1/s6-overlay-noarch.tar.xz
+          wget https://github.com/just-containers/s6-overlay/releases/download/v3.1.2.1/s6-overlay-symlinks-arch.tar.xz
+          wget https://github.com/just-containers/s6-overlay/releases/download/v3.1.2.1/s6-overlay-symlinks-noarch.tar.xz
           unxz s6-overlay*.tar.xz
           gzip s6-overlay*.tar
           docker build --build-arg SCHEME="https" --file ${{ matrix.ci_type }}/Containerfile --tag pulp/${{ matrix.ci_image }}:https .

--- a/.github/workflows/publish_images.yaml
+++ b/.github/workflows/publish_images.yaml
@@ -21,10 +21,10 @@ jobs:
       - uses: actions/checkout@v2
       - name: Download s6-overlay
         run: |
-          wget https://github.com/just-containers/s6-overlay/releases/download/v3.1.2.0/s6-overlay-x86_64.tar.xz
-          wget https://github.com/just-containers/s6-overlay/releases/download/v3.1.2.0/s6-overlay-noarch.tar.xz
-          wget https://github.com/just-containers/s6-overlay/releases/download/v3.1.2.0/s6-overlay-symlinks-arch.tar.xz
-          wget https://github.com/just-containers/s6-overlay/releases/download/v3.1.2.0/s6-overlay-symlinks-noarch.tar.xz
+          wget https://github.com/just-containers/s6-overlay/releases/download/v3.1.2.1/s6-overlay-x86_64.tar.xz
+          wget https://github.com/just-containers/s6-overlay/releases/download/v3.1.2.1/s6-overlay-noarch.tar.xz
+          wget https://github.com/just-containers/s6-overlay/releases/download/v3.1.2.1/s6-overlay-symlinks-arch.tar.xz
+          wget https://github.com/just-containers/s6-overlay/releases/download/v3.1.2.1/s6-overlay-symlinks-noarch.tar.xz
           unxz s6-overlay*.tar.xz
           gzip s6-overlay*.tar
       - name: Set version
@@ -126,10 +126,10 @@ jobs:
       - uses: actions/checkout@v2
       - name: Download s6-overlay
         run: |
-          wget https://github.com/just-containers/s6-overlay/releases/download/v3.1.2.0/s6-overlay-x86_64.tar.xz
-          wget https://github.com/just-containers/s6-overlay/releases/download/v3.1.2.0/s6-overlay-noarch.tar.xz
-          wget https://github.com/just-containers/s6-overlay/releases/download/v3.1.2.0/s6-overlay-symlinks-arch.tar.xz
-          wget https://github.com/just-containers/s6-overlay/releases/download/v3.1.2.0/s6-overlay-symlinks-noarch.tar.xz
+          wget https://github.com/just-containers/s6-overlay/releases/download/v3.1.2.1/s6-overlay-x86_64.tar.xz
+          wget https://github.com/just-containers/s6-overlay/releases/download/v3.1.2.1/s6-overlay-noarch.tar.xz
+          wget https://github.com/just-containers/s6-overlay/releases/download/v3.1.2.1/s6-overlay-symlinks-arch.tar.xz
+          wget https://github.com/just-containers/s6-overlay/releases/download/v3.1.2.1/s6-overlay-symlinks-noarch.tar.xz
           unxz s6-overlay*.tar.xz
           gzip s6-overlay*.tar
       - name: Set version

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ For instructions how to run and use this container, see [Pulp in One Container](
 # Build instructions
 
 ```bash
-$ wget https://github.com/just-containers/s6-overlay/releases/download/v3.1.2.0/s6-overlay-x86_64.tar.xz
-$ wget https://github.com/just-containers/s6-overlay/releases/download/v3.1.2.0/s6-overlay-noarch.tar.xz
-$ wget https://github.com/just-containers/s6-overlay/releases/download/v3.1.2.0/s6-overlay-symlinks-arch.tar.xz
-$ wget https://github.com/just-containers/s6-overlay/releases/download/v3.1.2.0/s6-overlay-symlinks-noarch.tar.xz
+$ wget https://github.com/just-containers/s6-overlay/releases/download/v3.1.2.1/s6-overlay-x86_64.tar.xz
+$ wget https://github.com/just-containers/s6-overlay/releases/download/v3.1.2.1/s6-overlay-noarch.tar.xz
+$ wget https://github.com/just-containers/s6-overlay/releases/download/v3.1.2.1/s6-overlay-symlinks-arch.tar.xz
+$ wget https://github.com/just-containers/s6-overlay/releases/download/v3.1.2.1/s6-overlay-symlinks-noarch.tar.xz
 $ unxz s6-overlay*.tar.xz
 $ gzip s6-overlay*.tar
 $ <docker build | buildah bud> --file pulp_ci_centos/Containerfile --tag pulp/pulp-ci-centos:latest .


### PR DESCRIPTION
Fixes running interactive shell in the container.