### PR TITLE
Restore /etc/fix-attrs.d/postgres

### DIFF
--- a/assets/fix-attrs.d/postgres
+++ b/assets/fix-attrs.d/postgres
@@ -1,0 +1,1 @@
+/var/lib/pgsql true postgres 0600 0750

--- a/pulp_ci_centos/Containerfile
+++ b/pulp_ci_centos/Containerfile
@@ -103,6 +103,7 @@ COPY assets/nginx.conf /nginx/nginx.conf
 COPY assets/webserver.sh /nginx/webserver.sh
 COPY assets/s6-rc.d /etc/s6-overlay/s6-rc.d
 COPY assets/init /etc/init
+COPY assets/fix-attrs.d /etc/fix-attrs.d
 
 RUN /nginx/webserver.sh
 


### PR DESCRIPTION
Fixes being unable to start the container image when /var/lib/pgsql
is mounted.