### PR TITLE
Removes all non-GA plugins from single container

### DIFF
--- a/CHANGES/265.removal
+++ b/CHANGES/265.removal
@@ -1,0 +1,2 @@
+Removed all non-GA plugins from the single container which includes: pulp_cookbook, pulp_gem,
+pulp_npm, and pulp_ostree.

--- a/pulp_nightly/Containerfile
+++ b/pulp_nightly/Containerfile
@@ -6,13 +6,9 @@ RUN pip3 install --upgrade \
   git+https://github.com/pulp/pulp_ansible@main \
   git+https://github.com/pulp/pulp-certguard@main \
   git+https://github.com/pulp/pulp_container@main \
-  git+https://github.com/pulp/pulp_cookbook@main \
   git+https://github.com/pulp/pulp_deb@main \
   git+https://github.com/pulp/pulp_file@main \
-  git+https://github.com/pulp/pulp_gem@main \
   git+https://github.com/pulp/pulp_maven@main \
-  git+https://github.com/pulp/pulp_npm@main \
-  git+https://github.com/pulp/pulp_ostree@main \
   git+https://github.com/pulp/pulp_python@main \
   git+https://github.com/pulp/pulp_rpm@main \
   requests && \
@@ -20,5 +16,4 @@ RUN pip3 install --upgrade \
 
 RUN ln /usr/local/lib/python3.8/site-packages/pulp_ansible/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_ansible.conf
 RUN ln /usr/local/lib/python3.8/site-packages/pulp_container/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_container.conf
-RUN ln /usr/local/lib/python3.8/site-packages/pulp_cookbook/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_cookbook.conf
 RUN ln /usr/local/lib/python3.8/site-packages/pulp_python/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_python.conf


### PR DESCRIPTION
This includes pulp_cookbook, pulp_gem, pulp_npm, and pulp_ostree.

closes #265