### PR TITLE
Change pulp dir owners

### DIFF
--- a/images/Containerfile.core.base
+++ b/images/Containerfile.core.base
@@ -75,7 +75,9 @@ RUN ln -s /usr/lib64/libldap.so /usr/lib64/libldap_r.so
 
 RUN PULP_STATIC_ROOT=/var/lib/operator/static/ PULP_CONTENT_ORIGIN=localhost \
 	/usr/local/bin/pulpcore-manager collectstatic --clear --noinput --link && \
-	chown -R 1000 /var/lib/operator/static/
+	chown -R 700 /var/lib/operator/static/
+
+RUN chown -R 700 /var/lib/pulp/
 
 COPY images/assets/readyz.py /usr/bin/readyz.py
 COPY images/assets/route_paths.py /usr/bin/route_paths.py


### PR DESCRIPTION
This is an update to try to run pulpcore containers as a regular user in k8s environments: https://github.com/pulp/pulp-operator/issues/627
[noissue]