### PR TITLE
Fix galaxy not starting due to being unable to

### DIFF
--- a/CHANGES/302.bugfix
+++ b/CHANGES/302.bugfix
@@ -1,0 +1,1 @@
+Fix galaxy not starting due to being unable to write to /var/log/galaxy_api_access.log

--- a/s6_images/pulp_ci_centos/Containerfile
+++ b/s6_images/pulp_ci_centos/Containerfile
@@ -110,6 +110,11 @@ COPY s6_images/assets/s6-rc.d /etc/s6-overlay/s6-rc.d
 COPY s6_images/assets/init /etc/init
 COPY s6_images/assets/fix-attrs.d /etc/fix-attrs.d
 
+# Need to precreate when running pulp as the pulp user
+RUN touch /var/log/galaxy_api_access.log && \
+    chown pulp:pulp /var/log/galaxy_api_access.log && \
+    chmod u+rw /var/log/galaxy_api_access.log
+
 RUN /nginx/webserver.sh
 
 ENTRYPOINT ["/init"]


### PR DESCRIPTION
write to /var/log/galaxy_api_access.log

fixes: #302