### PR TITLE
Set HOME env var on processes running as pulp

### DIFF
--- a/s6_images/assets/s6-rc.d/pulpcore-api/run
+++ b/s6_images/assets/s6-rc.d/pulpcore-api/run
@@ -10,4 +10,5 @@ foreground {
 }
 export DJANGO_SETTINGS_MODULE pulpcore.app.settings
 export PULP_SETTINGS /etc/pulp/settings.py
+export HOME /var/lib/pulp/
 /usr/local/bin/gunicorn pulpcore.app.wsgi:application --bind "127.0.0.1:24817" --name pulp-api --timeout 90 --access-logfile - --access-logformat "pulp [%({correlation-id}o)s]: %(h)s %(l)s %(u)s %(t)s \"%(r)s\" %(s)s %(b)s \"%(f)s\" \"%(a)s\""

--- a/s6_images/assets/s6-rc.d/pulpcore-content/run
+++ b/s6_images/assets/s6-rc.d/pulpcore-content/run
@@ -5,4 +5,5 @@ foreground {
 }
 export DJANGO_SETTINGS_MODULE pulpcore.app.settings
 export PULP_SETTINGS /etc/pulp/settings.py
+export HOME /var/lib/pulp/
 /usr/local/bin/gunicorn pulpcore.content:server --bind "127.0.0.1:24816" --name pulp-content --timeout 90 --worker-class "aiohttp.GunicornWebWorker" -w 2 --access-logfile -

--- a/s6_images/assets/s6-rc.d/pulpcore-worker@1/run
+++ b/s6_images/assets/s6-rc.d/pulpcore-worker@1/run
@@ -6,4 +6,5 @@ foreground {
 export DJANGO_SETTINGS_MODULE pulpcore.app.settings
 export PULP_SETTINGS /etc/pulp/settings.py
 export PATH /usr/local/bin:/usr/bin/
+export HOME /var/lib/pulp/
 /usr/local/bin/pulpcore-worker

--- a/s6_images/assets/s6-rc.d/pulpcore-worker@2/run
+++ b/s6_images/assets/s6-rc.d/pulpcore-worker@2/run
@@ -6,4 +6,5 @@ foreground {
 export DJANGO_SETTINGS_MODULE pulpcore.app.settings
 export PULP_SETTINGS /etc/pulp/settings.py
 export PATH /usr/local/bin:/usr/bin/
+export HOME /var/lib/pulp/
 /usr/local/bin/pulpcore-worker


### PR DESCRIPTION
s6-setuidgid doesn't set the user's home dir.

[noissue]