### PR TITLE
assets: Don't show password in pulp-api logs

### DIFF
--- a/images/assets/pulp-api
+++ b/images/assets/pulp-api
@@ -10,7 +10,7 @@
 /usr/local/bin/pulpcore-manager migrate --noinput
 /usr/local/bin/pulpcore-manager migrate auth --noinput
 
-bash +x
+set +x
 
 if [ -n "${PULP_SIGNING_KEY_FINGERPRINT}" ]; then
     /usr/local/bin/pulpcore-manager add-signing-service "${COLLECTION_SIGNING_SERVICE}" /var/lib/pulp/scripts/collection_sign.sh "${PULP_SIGNING_KEY_FINGERPRINT}"
@@ -26,7 +26,7 @@ fi
 if [ -n "${PULP_ADMIN_PASSWORD}" ]; then
     /usr/local/bin/pulpcore-manager reset-admin-password --password "${PULP_ADMIN_PASSWORD}"
 fi
-bash -x
+set -x
 
 PULP_GUNICORN_TIMEOUT=${PULP_GUNICORN_TIMEOUT:-90}
 PULP_API_WORKERS=${PULP_API_WORKERS:-2}


### PR DESCRIPTION
This was supposed to be fixed in [1] but this doesn't work. We should use `set` instead of `bash`

Before:
```bash
+ bash +x
+ '[' -n '' ']'
+ ADMIN_PASSWORD_FILE=/etc/pulp/pulp-admin-password
+ [[ -f /etc/pulp/pulp-admin-password ]]
+ echo 'pulp admin can be initialized.' pulp admin can be initialized.
++ cat /etc/pulp/pulp-admin-password
+ PULP_ADMIN_PASSWORD=xxxxxxxxxxxx
+ '[' -n xxxxxxxxxxxx ']'
+ /usr/bin/pulpcore-manager reset-admin-password --password xxxxxxxxxxxx
+ bash -x
+ PULP_GUNICORN_TIMEOUT=90
+ PULP_API_WORKERS=2
```

After:
```bash
+ set +x
pulp admin can be initialized.
+ PULP_GUNICORN_TIMEOUT=90
+ PULP_API_WORKERS=2
```

[noissue]

[1] https://github.com/pulp/pulp-operator/commit/2a158151

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>