### PR TITLE
base image: Add swig package

### DIFF
--- a/CHANGES/339.bugfix
+++ b/CHANGES/339.bugfix
@@ -1,0 +1,1 @@
+Install swig that is required when no binary wheel is available on PyPI for the solv package.

--- a/images/Containerfile.core.base
+++ b/images/Containerfile.core.base
@@ -42,6 +42,7 @@ RUN dnf -y install dnf-plugins-core && \
     dnf -y install python3-libcomps && \
     dnf -y install libpq-devel && \
     dnf -y install python3-setuptools && \
+    dnf -y install swig && \
     dnf -y install buildah --exclude container-selinux && \
     dnf -y install xz && \
     dnf -y install libmodulemd-devel && \


### PR DESCRIPTION
Required for building libsolv python bindings when installing from pip on non-x86_64 platforms where there is no pre-built binary wheel available from PyPI.

Fixes: #339 