### PR TITLE
The `images/compose` directory is now compatible

### DIFF
--- a/.github/workflows/pr_build_images.yaml
+++ b/.github/workflows/pr_build_images.yaml
@@ -78,8 +78,8 @@ jobs:
       - name: Compose up
         run: |
           cd images/compose
-          sed -i "s/pulp-minimal:latest/${{ matrix.test_image }}:latest/g" podman-compose.yml
-          sed -i "s/pulp\/pulp-web/quay.io\/pulp\/pulp-web/g" podman-compose.yml
+          sed -i "s/pulp-minimal:latest/${{ matrix.test_image }}:latest/g" docker-compose.yml
+          sed -i "s/pulp\/pulp-web/quay.io\/pulp\/pulp-web/g" docker-compose.yml
           sudo usermod -G root $(whoami)
           podman-compose up -d
           sleep 30

--- a/.github/workflows/publish_images.yaml
+++ b/.github/workflows/publish_images.yaml
@@ -100,8 +100,8 @@ jobs:
       - name: Compose up
         run: |
           cd images/compose
-          sed -i "s/pulp-minimal:latest/pulp:${VERSION}/g" podman-compose.yml
-          sed -i "s/pulp\/pulp-web/quay.io\/pulp\/pulp-web/g" podman-compose.yml
+          sed -i "s/pulp-minimal:latest/pulp:${VERSION}/g" docker-compose.yml
+          sed -i "s/pulp\/pulp-web/quay.io\/pulp\/pulp-web/g" docker-compose.yml
           sudo usermod -G root $(whoami)
           podman-compose up -d
           sleep 30

--- a/.github/workflows/pulp_images.yml
+++ b/.github/workflows/pulp_images.yml
@@ -48,8 +48,8 @@ jobs:
       - name: Compose up
         run: |
           cd images/compose
-          sed -i "s/pulp-minimal:latest/pulp-minimal:${{ matrix.image_tag }}/g" podman-compose.yml
-          sed -i "s/pulp-web:latest/pulp-web:${{ matrix.image_tag }}/g" podman-compose.yml
+          sed -i "s/pulp-minimal:latest/pulp-minimal:${{ matrix.image_tag }}/g" docker-compose.yml
+          sed -i "s/pulp-web:latest/pulp-web:${{ matrix.image_tag }}/g" docker-compose.yml
           sudo usermod -G root $(whoami)
           podman-compose up -d
           sleep 30
@@ -228,8 +228,8 @@ jobs:
       - name: Compose up
         run: |
           cd images/compose
-          sed -i "s/pulp-minimal:latest/galaxy-minimal:${{ matrix.image_tag }}/g" podman-compose.yml
-          sed -i "s/pulp-web:latest/galaxy-web:${{ matrix.image_tag }}/g" podman-compose.yml
+          sed -i "s/pulp-minimal:latest/galaxy-minimal:${{ matrix.image_tag }}/g" docker-compose.yml
+          sed -i "s/pulp-web:latest/galaxy-web:${{ matrix.image_tag }}/g" docker-compose.yml
           sudo usermod -G root $(whoami)
           podman-compose up -d
           sleep 30

--- a/CHANGES/343.feature
+++ b/CHANGES/343.feature
@@ -1,0 +1,1 @@
+The `images/compose` directory is now compatible with docker-compose in addition to podman-compose. pulp-api and pulp-content are now also scalable, even at runtime, in docker-compose. The ability to access pulp-content and pulp-api at host ports 24816 and 24817 has been removed in order to implement this, access them via the nginx webserver at port 8080 instead.

--- a/images/compose/README.md
+++ b/images/compose/README.md
@@ -11,3 +11,13 @@ git clone git@github.com:pulp/pulp-oci-images.git
 cd images/compose
 podman-compose up
 ```
+
+or:
+
+```shell
+pip install docker-compose
+git clone git@github.com:pulp/pulp-oci-images.git
+cd images/compose
+docker-compose up
+docker-compose scale pulp_api=4 pulp_content=4
+```

--- a/images/compose/assets/bin/nginx.sh
+++ b/images/compose/assets/bin/nginx.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# This logic enables us to have multiple servers, and check to see
+# if they are scaled every 10 seconds.
+# https://serverfault.com/a/821625/189494
+# https://www.nginx.com/blog/dns-service-discovery-nginx-plus#domain-name-variable
+
+set -e
+
+export NAMESERVER=`cat /etc/resolv.conf | grep "nameserver" | awk '{print $2}' | tr '\n' ' '`
+
+echo "Nameserver is: $NAMESERVER"
+
+echo "Generating nginx config"
+envsubst '$NAMESERVER' < /etc/opt/rh/rh-nginx116/nginx/nginx.conf.template > /etc/opt/rh/rh-nginx116/nginx/nginx.conf
+
+# We cannot use upstream server groups with a DNS resolver without nginx plus
+# So we modifying the files to use the variables rather than the upstream server groups
+for file in /opt/app-root/etc/nginx.default.d/*.conf ; do
+  echo "Modifying $file"
+  sed -i 's/pulp-api/$pulp_api:24817/' $file
+  sed -i 's/pulp-content/$pulp_content:24816/' $file
+done
+
+echo "Starting nginx"
+exec nginx  -g "daemon off;"

--- a/images/compose/assets/nginx/nginx.conf.template
+++ b/images/compose/assets/nginx/nginx.conf.template
@@ -16,16 +16,15 @@ http {
     # to build optimal hash types.
     types_hash_max_size 4096;
 
-    upstream pulp-content {
-        server pulp_content:24816;
-    }
-
-    upstream pulp-api {
-        server pulp_api:24817;
-    }
-
-
     server {
+        # This logic enables us to have multiple servers, and check to see
+        # if they are scaled every 10 seconds.
+        # https://www.nginx.com/blog/dns-service-discovery-nginx-plus#domain-name-variable
+        # https://serverfault.com/a/821625/189494
+        resolver $NAMESERVER valid=10s;
+        set $pulp_api pulp_api;
+        set $pulp_content pulp_content;
+
         # Gunicorn docs suggest the use of the "deferred" directive on Linux.
         listen 8080 default_server deferred;
         listen [::]:8080 default_server deferred;
@@ -51,7 +50,7 @@ http {
             # we don't want nginx trying to do something clever with
             # redirects, we set the Host: header above already.
             proxy_redirect off;
-            proxy_pass http://pulp-content;
+            proxy_pass http://$pulp_content:24816;
         }
 
         location /pulp/api/v3/ {
@@ -61,7 +60,7 @@ http {
             # we don't want nginx trying to do something clever with
             # redirects, we set the Host: header above already.
             proxy_redirect off;
-            proxy_pass http://pulp-api;
+            proxy_pass http://$pulp_api:24817;
         }
 
         location /auth/login/ {
@@ -71,7 +70,7 @@ http {
             # we don't want nginx trying to do something clever with
             # redirects, we set the Host: header above already.
             proxy_redirect off;
-            proxy_pass http://pulp-api;
+            proxy_pass http://$pulp_api:24817;
         }
 
         include /opt/app-root/etc/nginx.default.d/*.conf;
@@ -83,7 +82,7 @@ http {
             # we don't want nginx trying to do something clever with
             # redirects, we set the Host: header above already.
             proxy_redirect off;
-            proxy_pass http://pulp-api;
+            proxy_pass http://$pulp_api:24817;
             # static files are served through whitenoise - http://whitenoise.evans.io/en/stable/
         }
     }

--- a/images/compose/docker-compose.yml
+++ b/images/compose/docker-compose.yml
@@ -20,6 +20,7 @@ services:
 
   pulp_web:
     image: "pulp/pulp-web:latest"
+    command: ['/usr/bin/nginx.sh']
     depends_on:
       - postgres
       - pulp_api
@@ -29,18 +30,19 @@ services:
     hostname: pulp
     user: root
     volumes:
-      - "./assets/nginx/nginx.conf:/etc/opt/rh/rh-nginx116/nginx/nginx.conf:z"
+      - "./assets/bin/nginx.sh:/usr/bin/nginx.sh:z"
+      - "./assets/nginx/nginx.conf.template:/etc/opt/rh/rh-nginx116/nginx/nginx.conf.template:z"
 
   pulp_api:
     image: "pulp/pulp-minimal:latest"
-    ports:
-      - "24817:24817"
+    deploy:
+      replicas: 2
     command: ['pulp-api']
     depends_on:
       - redis
       - postgres
     hostname: pulp-api
-    user: 700
+    user: pulp
     volumes:
       - "./assets/settings.py:/etc/pulp/settings.py:z"
       - "./assets/certs:/etc/pulp/certs:z"
@@ -52,14 +54,14 @@ services:
 
   pulp_content:
     image: "pulp/pulp-minimal:latest"
-    ports:
-      - "24816:24816"
+    deploy:
+      replicas: 2
     command: ['pulp-content']
     depends_on:
       - redis
       - postgres
     hostname: pulp-content
-    user: 700
+    user: pulp
     volumes:
       - "./assets/settings.py:/etc/pulp/settings.py:z"
       - "./assets/certs:/etc/pulp/certs:z"
@@ -77,7 +79,7 @@ services:
       - redis
       - postgres
     hostname: pulp-worker
-    user: 700
+    user: pulp
     volumes:
       - "./assets/settings.py:/etc/pulp/settings.py:z"
       - "./assets/certs:/etc/pulp/certs:z"


### PR DESCRIPTION
with docker-compose in addition to podman-compose.

pulp-api and pulp-content are now also scalable,
even at runtime, in docker-compose.

The ability to access pulp-content and pulp-api at host ports 24816 and 24817 has been removed in order to implement this, access them via the nginx webserver at port 8080 instead.

fixes: #343