### PR TITLE
Make the data dirs compatible between compose and

### DIFF
--- a/.github/workflows/pr_build_images.yaml
+++ b/.github/workflows/pr_build_images.yaml
@@ -49,10 +49,12 @@ jobs:
             ci_image: pulp-ci-centos
             test_type: pulp_galaxy_ng
             test_image: pulp-galaxy-ng
+            web_image: galaxy-web
           - ci_type: pulp_ci_centos
             ci_image: pulp-ci-centos
             test_type: pulp
             test_image: pulp
+            web_image: pulp-web
     steps:
       - uses: actions/checkout@v2
       - name: Install httpie and podman-compose
@@ -70,7 +72,15 @@ jobs:
           podman build --file images/Containerfile.core.base --tag pulp/base:latest .
           podman build --file images/${{ matrix.ci_type }}/Containerfile --tag pulp/${{ matrix.ci_image }}:latest .
           podman build --file images/${{ matrix.test_type }}/Containerfile --tag pulp/${{ matrix.test_image }}:latest .
-      - name: Test the images in s6 mode
+      - name: Test upgrading to the image in s6 mode
+        if: matrix.test_image == 'pulp'
+        run: |
+          # 3.20 has postgres 12 rather than 13
+          images/s6_assets/test.sh "pulp/${{ matrix.test_image }}:latest" http "quay.io/pulp/all-in-one-pulp:3.20"
+          podman stop pulp
+          podman rm pulp
+      - name: Test the image in s6 mode
+        if: matrix.test_image != 'pulp'
         run: |
           images/s6_assets/test.sh "pulp/${{ matrix.test_image }}:latest"
           podman stop pulp
@@ -78,10 +88,10 @@ jobs:
       - name: Compose up
         run: |
           cd images/compose
-          sed -i "s/pulp-minimal:latest/${{ matrix.test_image }}:latest/g" docker-compose.yml
-          sed -i "s/pulp\/pulp-web/quay.io\/pulp\/pulp-web/g" docker-compose.yml
-          sudo usermod -G root $(whoami)
-          podman-compose up -d
+          sed -i "s/pulp-minimal:latest/${{ matrix.test_image }}:latest/g" docker-compose.folders.yml
+          sed -i "s/pulp\/pulp-web/pulp\/${{ matrix.web_image }}/g" docker-compose.folders.yml
+          id | grep "(root)" || sudo usermod -G root $(whoami)
+          podman-compose -f docker-compose.folders.yml up -d
           sleep 30
           for _ in $(seq 20)
           do
@@ -109,9 +119,12 @@ jobs:
         shell: bash
         env:
           PY_COLORS: '1'
-      - name: Display log on error
-        if: failure()
-        run: podman logs pulp
+      - name: Display logs
+        if: always()
+        run: |
+          podman logs pulp || true
+          cd images/compose
+          podman-compose logs
 
   s6-ssl-images:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish_images.yaml
+++ b/.github/workflows/publish_images.yaml
@@ -97,12 +97,12 @@ jobs:
           podman stop pulp
           podman rm pulp
         shell: bash
-      - name: Compose up
+      - name: Compose up (pulp)
         run: |
           cd images/compose
           sed -i "s/pulp-minimal:latest/pulp:${VERSION}/g" docker-compose.yml
           sed -i "s/pulp\/pulp-web/quay.io\/pulp\/pulp-web/g" docker-compose.yml
-          sudo usermod -G root $(whoami)
+          id | grep "(root)" || sudo usermod -G root $(whoami)
           podman-compose up -d
           sleep 30
           for _ in $(seq 20)
@@ -116,7 +116,6 @@ jobs:
           curl --fail http://localhost:8080/pulp/api/v3/status/ | jq
         shell: bash
       - name: Test all components (pulp)
-        if: matrix.test_type == 'pulp'
         run: |
           git clone --depth=1 https://github.com/pulp/pulp_ansible.git
           git clone --depth=1 https://github.com/pulp/pulp_container.git
@@ -124,8 +123,28 @@ jobs:
         shell: bash
         env:
           PY_COLORS: '1'
+      - name: Reset docker-compose environment
+        run: |
+          podman-compose down -v
+          git checkout docker-compose.yml
+      - name: Compose up (galaxy)
+        run: |
+          cd images/compose
+          sed -i "s/pulp-minimal:latest/pulp-galaxy-ng:${VERSION}/g" docker-compose.yml
+          sed -i "s/pulp\/pulp-web/pulp\/galaxy-web/g" docker-compose.yml
+          id | grep "(root)" || sudo usermod -G root $(whoami)
+          podman-compose up -d
+          sleep 30
+          for _ in $(seq 20)
+          do
+            sleep 3
+            if curl --fail http://localhost:8080/pulp/api/v3/status/ > /dev/null 2>&1
+            then
+              break
+            fi
+          done
+          curl --fail http://localhost:8080/pulp/api/v3/status/ | jq
       - name: Test all components (galaxy)
-        if: matrix.test_type == 'pulp_galaxy_ng'
         run: |
           .ci/scripts/galaxy_ng-tests.sh
         shell: bash
@@ -176,9 +195,12 @@ jobs:
             # Let this be the last thing so it can indicate failure without breaking anything else
             podman push quay.io/pulp/pulp:nightly
           fi
-      - name: Display log on error
-        if: failure()
-        run: podman logs pulp
+      - name: Display log
+        if: always()
+        run: |
+          podman logs pulp || true
+          cd images/compose
+          podman-compose logs
 
   s6-ssl-publish:
     runs-on: ubuntu-latest

--- a/CHANGES/347.feature
+++ b/CHANGES/347.feature
@@ -1,0 +1,1 @@
+Make the data dirs compatible between compose and single container. Implementation includes: 1. single container gets upgraded to postgres 13, and performs the upgrade logic. 2. compose runs postgres as uid/gid 26.

--- a/images/compose/assets/bin/nginx.sh
+++ b/images/compose/assets/bin/nginx.sh
@@ -6,7 +6,14 @@
 
 set -e
 
-export NAMESERVER=`cat /etc/resolv.conf | grep "nameserver" | awk '{print $2}' | tr '\n' ' '`
+if [ "$container" != "podman" ]; then
+  # the nameserver list under podman is unreliable.
+  # It will look like "10.89.1.1 192.168.1.1 192.168.1.1", but only the 1st IP works.
+  # This doesn't mess up `nslookup`, but it messes up `getent hosts` and nginx.
+  export NAMESERVER=`cat /etc/resolv.conf | grep "nameserver" | awk '{print $2}' | head -n1`
+else
+  export NAMESERVER=`cat /etc/resolv.conf | grep "nameserver" | awk '{print $2}' | tr '\n' ' '`
+fi
 
 echo "Nameserver is: $NAMESERVER"
 

--- a/images/compose/assets/postgres/passwd
+++ b/images/compose/assets/postgres/passwd
@@ -1,0 +1,20 @@
+root:x:0:0:root:/root:/bin/bash
+daemon:x:1:1:daemon:/usr/sbin:/usr/sbin/nologin
+bin:x:2:2:bin:/bin:/usr/sbin/nologin
+sys:x:3:3:sys:/dev:/usr/sbin/nologin
+sync:x:4:65534:sync:/bin:/bin/sync
+games:x:5:60:games:/usr/games:/usr/sbin/nologin
+man:x:6:12:man:/var/cache/man:/usr/sbin/nologin
+lp:x:7:7:lp:/var/spool/lpd:/usr/sbin/nologin
+mail:x:8:8:mail:/var/mail:/usr/sbin/nologin
+news:x:9:9:news:/var/spool/news:/usr/sbin/nologin
+uucp:x:10:10:uucp:/var/spool/uucp:/usr/sbin/nologin
+proxy:x:13:13:proxy:/bin:/usr/sbin/nologin
+www-data:x:33:33:www-data:/var/www:/usr/sbin/nologin
+backup:x:34:34:backup:/var/backups:/usr/sbin/nologin
+list:x:38:38:Mailing List Manager:/var/list:/usr/sbin/nologin
+irc:x:39:39:ircd:/run/ircd:/usr/sbin/nologin
+gnats:x:41:41:Gnats Bug-Reporting System (admin):/var/lib/gnats:/usr/sbin/nologin
+nobody:x:65534:65534:nobody:/nonexistent:/usr/sbin/nologin
+_apt:x:100:65534::/nonexistent:/usr/sbin/nologin
+postgres:x:26:26::/var/lib/postgresql:/bin/bash

--- a/images/compose/docker-compose.folders.yml
+++ b/images/compose/docker-compose.folders.yml
@@ -11,7 +11,8 @@ services:
       POSTGRES_INITDB_ARGS: '--auth-host=scram-sha-256'
       POSTGRES_HOST_AUTH_METHOD: 'scram-sha-256'
     volumes:
-      - "../../pgsql:/var/lib/postgresql/data:z"
+      - "../../pgsql:/var/lib/postgresql:Z"
+      - "./assets/postgres/passwd:/etc/passwd:Z"
 
   redis:
     image: "docker.io/library/redis:latest"
@@ -30,8 +31,8 @@ services:
     hostname: pulp
     user: root
     volumes:
-      - "./assets/bin/nginx.sh:/usr/bin/nginx.sh:z"
-      - "./assets/nginx/nginx.conf.template:/etc/opt/rh/rh-nginx116/nginx/nginx.conf.template:z"
+      - "./assets/bin/nginx.sh:/usr/bin/nginx.sh:Z"
+      - "./assets/nginx/nginx.conf.template:/etc/opt/rh/rh-nginx116/nginx/nginx.conf.template:Z"
 
   pulp_api:
     image: "pulp/pulp-minimal:latest"

--- a/images/compose/docker-compose.yml
+++ b/images/compose/docker-compose.yml
@@ -11,7 +11,8 @@ services:
       POSTGRES_INITDB_ARGS: '--auth-host=scram-sha-256'
       POSTGRES_HOST_AUTH_METHOD: 'scram-sha-256'
     volumes:
-      - "pg_data:/var/lib/postgresql/data"
+      - "pg_data:/var/lib/postgresql"
+      - "./assets/postgres/passwd:/etc/passwd:Z"
 
   redis:
     image: "docker.io/library/redis:latest"
@@ -30,8 +31,8 @@ services:
     hostname: pulp
     user: root
     volumes:
-      - "./assets/bin/nginx.sh:/usr/bin/nginx.sh:z"
-      - "./assets/nginx/nginx.conf.template:/etc/opt/rh/rh-nginx116/nginx/nginx.conf.template:z"
+      - "./assets/bin/nginx.sh:/usr/bin/nginx.sh:Z"
+      - "./assets/nginx/nginx.conf.template:/etc/opt/rh/rh-nginx116/nginx/nginx.conf.template:Z"
 
   pulp_api:
     image: "pulp/pulp-minimal:latest"

--- a/images/pulp_ci_centos/Containerfile
+++ b/images/pulp_ci_centos/Containerfile
@@ -16,10 +16,11 @@ ENV S6_BEHAVIOUR_IF_STAGE2_FAILS=1
 # https://github.com/just-containers/s6-overlay/issues/467
 ENV S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0
 
-RUN dnf -y module enable postgresql:12 && \
+RUN dnf -y module enable postgresql:13 && \
     dnf -y install postgresql && \
     dnf -y install postgresql-contrib && \
     dnf -y install postgresql-server && \
+    dnf -y install postgresql-upgrade && \
     dnf -y install nginx && \
     dnf -y install redis && \
     dnf clean all

--- a/images/s6_assets/init/postgres-init
+++ b/images/s6_assets/init/postgres-init
@@ -13,16 +13,34 @@ export C035="\e[35m"
 export C036="\e[36m"
 export C037="\e[37m"
 
-PGVERSION=$(postgres --version | egrep -o "[0-9]{1,}\.[0-9]{1,}")
+PGVERSION=$(postgres --version | egrep -o "1[0-9]")
 PGHOME="/var/lib/pgsql"
 PGDATA="${PGHOME}/data"
+PGDATA_OLD="${PGHOME}/data_old"
+PGDATA_OLD_RENAMED="${PGHOME}/data_old.$(date --rfc-3339=seconds)"
 
 if [ -d "${PGDATA}/base" -a -f "${PGDATA}/PG_VERSION" ]; then
   PGDATA_VERSION=$(cat "${PGDATA}/PG_VERSION")
-  if [ "${PGDATA_VERSION}" = "${PGVERSION}" ]; then
+  if [ "${PGDATA_VERSION}" != "${PGVERSION}" ]; then
+    echo -e "${PREFIX} ${ORANGE} Postgresql database exists but will be upgraded from ${PGDATA_VERSION} to ${PGVERSION}${ENDCOLOR}"
+    if [ -d ${PGDATA_OLD} ]; then
+      echo -e "${PREFIX} ${ORANGE} Renaming ${PGDATA_OLD} ${PGDATA_OLD} to ${PGDATA_OLD_RENAMED}${ENDCOLOR}"
+      mv ${PGDATA_OLD} "${PGDATA_OLD_RENAMED}"
+    fi
 
-    echo -e "${PREFIX} ${RED}${PGDATA} exists but needs upgrade ${PGDATA_VERSION} != ${PGVERSION}${ENDCOLOR}"
-    exit 200
+    # We have to check the encoding and the locale because pulp/pulp-oci-images #307 (1da694c) means it may differ.
+    # In order to check the encoding and the locale, we have to start the postgresql server,
+    # and we have to do so with the v12 binaries from the "postgresql-upgrade" RPM package.
+    # (We only support upgrading from v12 because that's all that the pulp single (s6) container has ever used previously.)
+    # This particular command `pg_ctl start` does not block.
+    su postgres -c "/usr/lib64/pgsql/postgresql-12/bin/pg_ctl start -D ${PGDATA}"
+    # The v12 binary listens on a non-standard socket under /tmp. So let's just use localhost (IP) instead.
+    ENCODING=$(su postgres -c "psql --host=localhost postgres -t -c 'SHOW server_encoding' | xargs")
+    LOCALE=$(su postgres -c "psql --host=localhost postgres -t -c 'SHOW lc_collate' | xargs")
+    su postgres -c "/usr/lib64/pgsql/postgresql-12/bin/pg_ctl stop -D ${PGDATA}"
+
+    echo -e "${PREFIX} ${ORANGE}PGSETUP_INITDB_OPTIONS=\"-E ${ENCODING} --locale=${LOCALE} --auth=trust\" postgresql-upgrade ${PGDATA}${ENDCOLOR}"
+    su postgres -c "PGSETUP_INITDB_OPTIONS=\"-E ${ENCODING} --locale=${LOCALE} --auth=trust\" postgresql-upgrade ${PGDATA}" || { echo -e "${PREFIX} ${RED} Failed to upgrade the postgresql database${ENDCOLOR}" ; exit 1; }
   fi
 else
   echo -e "${PREFIX} ${GREEN}initdb -E UTF8 --locale=C.UTF-8 --pgdata ${PGDATA}${ENDCOLOR}"


### PR DESCRIPTION
single container
    
Implementation includes:
1. single container gets upgraded to postgres 13, and performs the
upgrade logic.
2. compose runs postgres as uid/gid 26.
3. Fixing testing in docker compose pulp-galaxy-ng with galaxy-web
4. Testing the http s6 images in single container mode, then re-using
its data with docker-compose.
5. Working around podman DNS resolution with nginx.
    
fixes: #347
