### PR TITLE
assets: remove duplicate migrate call from api

### DIFF
--- a/images/assets/pulp-api
+++ b/images/assets/pulp-api
@@ -8,7 +8,6 @@
 # PLUGINS=$(pip list | awk -F '[[:space:]]+|[-]' '/pulp-/{printf $2 " " }')
 
 /usr/local/bin/pulpcore-manager migrate --noinput
-/usr/local/bin/pulpcore-manager migrate auth --noinput
 
 set +x
 


### PR DESCRIPTION
The `pulpcore-manager migrate` command already includes the auth migration so there's no need to run it explicitly after the first migration command.

```console
+ /usr/bin/pulpcore-manager migrate --noinput Operations to perform:
  Apply all migrations: ansible, auth, authtoken, container, contenttypes, core, galaxy, sessions Running migrations:
  No migrations to apply. Overriding pulp_container access policy
+ /usr/bin/pulpcore-manager migrate auth --noinput Operations to perform:
  Apply all migrations: auth Running migrations:
  No migrations to apply.
```

[noissue]

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>