### PR TITLE
Execute pulpcore-worker with exec so the sigterm from docker/kubernetes propagates properly

### DIFF
--- a/CHANGES/391.bugfix
+++ b/CHANGES/391.bugfix
@@ -1,0 +1,1 @@
+Execute pulpcore-worker with exec so the sigterm from docker/kubernetes propagates properly

--- a/images/assets/pulp-worker
+++ b/images/assets/pulp-worker
@@ -14,5 +14,5 @@ else
     export DJANGO_SETTINGS_MODULE=pulpcore.app.settings
     export PULP_SETTINGS=/etc/pulp/settings.py
     export PATH=/usr/local/bin:/usr/bin/
-    pulpcore-worker
+    exec pulpcore-worker
 fi


### PR DESCRIPTION
closes #391 

You are already correctly using `exec` in this same script for the `rq worker` command, and also in `pulp-api` and `pulp-content`. It got missed here though, so the worker process is never receiving the SIGTERM sent by Docker / Kubernetes when it wants to shut it down, and instead is always waiting for the timeout to kill it.