### PR TITLE
Modify container type check from probe script

### DIFF
--- a/CHANGES/399.bugfix
+++ b/CHANGES/399.bugfix
@@ -1,0 +1,1 @@
+Fixed an issue with readiness probe script getting wrong pulp container type.


### PR DESCRIPTION
This commit uses the information from entrypoint, instead of checking if an env var is defined, to identify the "type" of the container. fixes #399