### PR TITLE
Reassign user pulp as owner of the DB

### DIFF
--- a/CHANGES/414.bugfix
+++ b/CHANGES/414.bugfix
@@ -1,0 +1,1 @@
+Added a command to reown the db to pulp on each startup.

--- a/images/s6_assets/init/postgres-prepare
+++ b/images/s6_assets/init/postgres-prepare
@@ -28,6 +28,8 @@ if [ "${DATABASE_EXISTS}" != "1" ]; then
   su postgres -c "createuser pulp" || { echo -e "${PREFIX} ${RED} Creating database user failed${ENDCOLOR}" ; exit 1; }
   echo -e "${PREFIX} ${GREEN}createdb --encoding=utf-8 --locale=en_US.UTF-8 -T template0 -O pulp pulp${ENDCOLOR}"
   su postgres -c "createdb --encoding=utf-8 --locale=en_US.UTF-8 -T template0 -O pulp pulp" || { echo -e "${PREFIX} ${RED} Creating database failed${ENDCOLOR}" ; exit 1; }
+else
+  psql --user postgres -c "ALTER DATABASE pulp OWNER TO pulp;"
 fi
 
 export DJANGO_SETTINGS_MODULE=pulpcore.app.settings


### PR DESCRIPTION
It seems that on container restart the ownership of the database may have been wrong. This leads to the unability to create trusted Postgres extensions.

[noissue]