### PR TITLE
Add restart to docker-compose

### DIFF
--- a/CHANGES/418.bugfix
+++ b/CHANGES/418.bugfix
@@ -1,0 +1,1 @@
+Fixed bug where all workers had the same name when started using docker-compose.

--- a/CHANGES/419.bugfix
+++ b/CHANGES/419.bugfix
@@ -1,0 +1,2 @@
+
+Fixed bug in docker-compose file that prevented managed services from automatically restarting upon failure.

--- a/images/compose/docker-compose.yml
+++ b/images/compose/docker-compose.yml
@@ -13,11 +13,13 @@ services:
     volumes:
       - "pg_data:/var/lib/postgresql"
       - "./assets/postgres/passwd:/etc/passwd:Z"
+    restart: always
 
   redis:
     image: "docker.io/library/redis:latest"
     volumes:
       - "redis_data:/data"
+    restart: always
 
   pulp_web:
     image: "pulp/pulp-web:latest"
@@ -33,6 +35,7 @@ services:
     volumes:
       - "./assets/bin/nginx.sh:/usr/bin/nginx.sh:Z"
       - "./assets/nginx/nginx.conf.template:/etc/opt/rh/rh-nginx116/nginx/nginx.conf.template:Z"
+    restart: always
 
   pulp_api:
     image: "pulp/pulp-minimal:latest"
@@ -52,6 +55,7 @@ services:
       POSTGRES_SERVICE_PORT: 5432
       POSTGRES_SERVICE_HOST: postgres
       PULP_ADMIN_PASSWORD: password
+    restart: always
 
   pulp_content:
     image: "pulp/pulp-minimal:latest"
@@ -70,6 +74,7 @@ services:
     environment:
       POSTGRES_SERVICE_PORT: 5432
       POSTGRES_SERVICE_HOST: postgres
+    restart: always
 
   pulp_worker:
     image: "pulp/pulp-minimal:latest"
@@ -79,7 +84,6 @@ services:
     depends_on:
       - redis
       - postgres
-    hostname: pulp-worker
     user: pulp
     volumes:
       - "./assets/settings.py:/etc/pulp/settings.py:z"
@@ -88,6 +92,7 @@ services:
     environment:
       POSTGRES_SERVICE_PORT: 5432
       POSTGRES_SERVICE_HOST: postgres
+    restart: always
 
 volumes:
   pulp:


### PR DESCRIPTION
This patch also removes the hostname parameter from the pulp-worker service.

fixes: #419
fixes: #418