### PR TITLE
readyz.py: Fix api/content type check

### DIFF
--- a/CHANGES/402.bugfix
+++ b/CHANGES/402.bugfix
@@ -1,0 +1,1 @@
+Fix readiness probe script based on gunicorn install method.


### PR DESCRIPTION
Depending on the gunicorn install method (RPM vs pip) then the entrypoint doesn't provide the same result and the readiness script doesn't work for all scenarios.

Closes: #402

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>