### PR TITLE
Enable stable branches to build single-process

### DIFF
--- a/CHANGES/457.bugfix
+++ b/CHANGES/457.bugfix
@@ -1,0 +1,1 @@
+Enable stable branches to build single-process images with old pulpcore version.

--- a/docs/developer-instructions.md
+++ b/docs/developer-instructions.md
@@ -9,9 +9,9 @@ pulpcore z-release, the existing y-release branch is built and published again.
 
 * First create a new release branch in this pulp-oci-images repo for the prior Y release
   (if it does not already exist.) So if you are releasing 3.23, create the 3.22 branch.
-* Update PULPCORE_VERSION in images/pulp/stable/Containerfile on the release branch (see
-  [here](https://github.com/pulp/pulp-oci-images/pull/61/files) as an example)
-* Update `branches` in `.ci/scripts/update_ci_branches.py` to include the prior Y release.
-* Kick off a new build from the release branch at [the workflow](https://github.com/pulp/pulp-oci-images/actions/workflows/pulp_images.yml)
-  (Afterwards, it will auto-build nightly.)
-
+* Update PULPCORE_VERSION in the following files on the prior Y release branch
+  (see [here](https://github.com/pulp/pulp-oci-images/pull/61/files) as an example, albeit of only 1 file):
+  * images/pulp/stable/Containerfile
+  * images/pulp-minimal/stable/Containerfile.core
+* Update `branches` on the latest branch `.ci/scripts/update_ci_branches.py` to include the prior Y release.
+  (Once merged, it will trigger a build of the new released version from the latest branch.)

--- a/images/galaxy-minimal/stable/Containerfile.core
+++ b/images/galaxy-minimal/stable/Containerfile.core
@@ -1,7 +1,13 @@
 ARG FROM_TAG="latest"
 FROM pulp/base:${FROM_TAG}
 
-RUN pip3 install galaxy_ng
+ARG PULPCORE_VERSION=""
+ARG GALAXY_NG_VERSION=""
+
+RUN pip3 install --upgrade \
+  pulpcore${PULPCORE_VERSION} \
+  galaxy-ng${GALAXY_NG_VERSION} && \
+  rm -rf /root/.cache/pip
 
 USER pulp:pulp
 RUN PULP_STATIC_ROOT=/var/lib/operator/static/ PULP_CONTENT_ORIGIN=localhost \

--- a/images/galaxy/stable/Containerfile
+++ b/images/galaxy/stable/Containerfile
@@ -1,10 +1,12 @@
 ARG FROM_TAG="latest"
 FROM pulp/pulp-ci-centos:${FROM_TAG}
 
+ARG PULPCORE_VERSION=""
 ARG GALAXY_NG_VERSION=""
 
 RUN pip3 install --upgrade \
   requests \
+  pulpcore${PULPCORE_VERSION} \
   galaxy-ng${GALAXY_NG_VERSION} && \
   rm -rf /root/.cache/pip
 

--- a/images/pulp-minimal/stable/Containerfile.core
+++ b/images/pulp-minimal/stable/Containerfile.core
@@ -1,15 +1,27 @@
 ARG FROM_TAG="latest"
 FROM pulp/base:${FROM_TAG}
 
-RUN pip3 install pulpcore \
-  pulp_ansible \
-  pulp-certguard \
-  pulp_container \
-  pulp_deb \
-  pulp_file \
-  pulp_maven \
-  pulp_python \
-  pulp_rpm
+ARG PULPCORE_VERSION=""
+ARG PULP_ANSIBLE_VERSION=""
+ARG PULP_CERTGUARD_VERSION=""
+ARG PULP_CONTAINER_VERSION=""
+ARG PULP_DEB_VERSION=""
+ARG PULP_FILE_VERSION=""
+ARG PULP_MAVEN_VERSION=""
+ARG PULP_PYTHON_VERSION=""
+ARG PULP_RPM_VERSION=""
+
+RUN pip3 install --upgrade \
+  pulpcore${PULPCORE_VERSION} \
+  pulp-ansible${PULP_ANSIBLE_VERSION} \
+  pulp-certguard${PULP_CERTGUARD_VERSION} \
+  pulp-container${PULP_CONTAINER_VERSION} \
+  pulp-deb${PULP_DEB_VERSION} \
+  pulp-file${PULP_FILE_VERSION} \
+  pulp-maven${PULP_MAVEN_VERSION} \
+  pulp-python${PULP_PYTHON_VERSION} \
+  pulp-rpm${PULP_RPM_VERSION} && \
+  rm -rf /root/.cache/pip
 
 USER pulp:pulp
 RUN PULP_STATIC_ROOT=/var/lib/operator/static/ PULP_CONTENT_ORIGIN=localhost \


### PR DESCRIPTION
images with old pulpcore version.

See https://github.com/pulp/pulp-oci-images/blob/latest/images/pulp/stable/Containerfile for copied logic.

fixes: #457

related follow-up: #459