### PR TITLE
Add a default settings.py file for galaxy

### DIFF
--- a/docs/multi-process-images.md
+++ b/docs/multi-process-images.md
@@ -115,7 +115,7 @@ $ podman run --detach \
              -e "GALAXY_HOSTNAME=my.galaxy.host.example.com" \
              -e "PULP_HTTPS=true" \
              -e "GALAXY_PORT=443" \
-             --volume "$(pwd)/certs":/etc/pulp/certs:Z \
+             --volume "$(pwd)/settings/certs":/etc/pulp/certs:Z \
              --volume "$(pwd)/pulp_storage":/var/lib/pulp:Z \
              --volume "$(pwd)/pgsql":/var/lib/pgsql:Z \
              --volume "$(pwd)/containers":/var/lib/containers:Z \

--- a/images/galaxy/nightly/Containerfile
+++ b/images/galaxy/nightly/Containerfile
@@ -16,3 +16,7 @@ USER root:root
 RUN ln /usr/local/lib/python3.8/site-packages/pulp_ansible/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_ansible.conf
 RUN ln /usr/local/lib/python3.8/site-packages/pulp_container/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_container.conf
 RUN ln /usr/local/lib/python3.8/site-packages/galaxy_ng/app/webserver_snippets/nginx.conf /etc/nginx/pulp/galaxy_ng.conf
+
+# allow configuration via env variables
+ENV S6_KEEP_ENV=1
+COPY images/galaxy/settings.py /etc/pulp/settings.py

--- a/images/galaxy/settings.py
+++ b/images/galaxy/settings.py
@@ -1,0 +1,28 @@
+import os
+
+_CONTAINER_ENV_CONFIGS = {
+    "API_PROTOCOL": "https" if os.getenv("PULP_HTTPS", default="false") == "true" else "http",
+    "API_HOST": os.getenv("GALAXY_HOSTNAME", default="localhost"),
+    "API_PORT": os.getenv("GALAXY_PORT", default="5001")
+}
+
+CONTENT_ORIGIN='{API_PROTOCOL}://{API_HOST}:{API_PORT}'.format(**_CONTAINER_ENV_CONFIGS)
+ALLOWED_EXPORT_PATHS=["/tmp"]
+ALLOWED_IMPORT_PATHS=["/tmp"]
+
+GALAXY_API_PATH_PREFIX='/api/galaxy/'
+GALAXY_DEPLOYMENT_MODE='standalone'
+RH_ENTITLEMENT_REQUIRED='insights'
+GALAXY_REQUIRE_CONTENT_APPROVAL=False
+
+ANSIBLE_API_HOSTNAME="{API_PROTOCOL}://{API_HOST}:{API_PORT}".format(**_CONTAINER_ENV_CONFIGS)
+ANSIBLE_CONTENT_HOSTNAME="{API_PROTOCOL}://{API_HOST}:{API_PORT}/pulp/content".format(**_CONTAINER_ENV_CONFIGS)
+
+# Pulp container requires this to be set in order to provide docker registry
+# compatible token authentication.
+# https://docs.pulpproject.org/container/workflows/authentication.html
+TOKEN_AUTH_DISABLED=False
+TOKEN_SERVER="{API_PROTOCOL}://{API_HOST}:{API_PORT}/token/".format(**_CONTAINER_ENV_CONFIGS)
+TOKEN_SIGNATURE_ALGORITHM="ES256"
+PUBLIC_KEY_PATH="/etc/pulp/certs/token_public_key.pem"
+PRIVATE_KEY_PATH="/etc/pulp/certs/token_private_key.pem"

--- a/images/galaxy/settings.py
+++ b/images/galaxy/settings.py
@@ -3,7 +3,7 @@ import os
 _CONTAINER_ENV_CONFIGS = {
     "API_PROTOCOL": "https" if os.getenv("PULP_HTTPS", default="false") == "true" else "http",
     "API_HOST": os.getenv("GALAXY_HOSTNAME", default="localhost"),
-    "API_PORT": os.getenv("GALAXY_PORT", default="5001")
+    "API_PORT": os.getenv("GALAXY_PORT", default="8080")
 }
 
 CONTENT_ORIGIN='{API_PROTOCOL}://{API_HOST}:{API_PORT}'.format(**_CONTAINER_ENV_CONFIGS)

--- a/images/galaxy/stable/Containerfile
+++ b/images/galaxy/stable/Containerfile
@@ -18,3 +18,7 @@ USER root:root
 RUN ln /usr/local/lib/python3.8/site-packages/pulp_ansible/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_ansible.conf
 RUN ln /usr/local/lib/python3.8/site-packages/pulp_container/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_container.conf
 RUN ln /usr/local/lib/python3.8/site-packages/galaxy_ng/app/webserver_snippets/nginx.conf /etc/nginx/pulp/galaxy_ng.conf
+
+# allow configuration via env variables
+ENV S6_KEEP_ENV=1
+COPY images/galaxy/settings.py /etc/pulp/settings.py


### PR DESCRIPTION
This adds a default settings.py file to the galaxy image that allows for galaxy_ng to be run out of the box with very little configuration. The goal of this PR is to make the galaxy image as simple as possible for anyone to take for a spin.

Example usage
```
# run galaxy on localhost
podman run -p 8080:80  ghcr.io/pulp/galaxy:latest

# run galaxy on localhost with https
podman run -p 443:443 -e "PULP_HTTPS=true" -e "GALAXY_PORT=443"  ghcr.io/pulp/galaxy:latest

# run galaxy from a server with https
podman run -p 443:443 -e "PULP_HTTPS=true" -e "GALAXY_PORT=443" -e "GALAXY_HOSTNAME=192.168.0.100"  ghcr.io/pulp/galaxy:latest

# modify the system settings to allow for uploads without approval
podman run -p 8080:80  -e "PULP_GALAXY_REQUIRE_CONTENT_APPROVAL=false" ghcr.io/pulp/galaxy:latest
```

[noissue]