### PR TITLE
Removes the OpenTelemetry installation from the `pulp-ci-centos` image.

### DIFF
--- a/CHANGES/488.misc
+++ b/CHANGES/488.misc
@@ -1,0 +1,1 @@
+Removed the OpenTelemetry libraries installation from the ``pulp-ci-centos`` image.

--- a/images/pulp_ci_centos/Containerfile
+++ b/images/pulp_ci_centos/Containerfile
@@ -31,19 +31,6 @@ RUN dnf -y module enable postgresql:13 && \
     dnf -y install redis && \
     dnf clean all
 
-RUN pip install \
-opentelemetry-sdk \
-opentelemetry-instrumentation \
-opentelemetry-instrumentation-dbapi \
-opentelemetry-instrumentation-logging \
-opentelemetry-instrumentation-wsgi \
-opentelemetry-instrumentation-aiohttp-client \
-opentelemetry-instrumentation-botocore \
-opentelemetry-instrumentation-django \
-opentelemetry-instrumentation-psycopg2 \
-opentelemetry-instrumentation-redis \
-opentelemetry-distro[otlp]
-
 COPY images/s6_assets/openssl.cnf /etc/ssl/pulp/openssl.cnf
 COPY images/s6_assets/v3.cnf /etc/ssl/pulp/v3.cnf
 COPY images/s6_assets/wait_on_database_migrations.sh /database/assets/wait_on_database_migrations.sh


### PR DESCRIPTION
Closes #488
