### PR TITLE
Move the mkdir to the top of the api script

### DIFF
--- a/CHANGES/472.misc
+++ b/CHANGES/472.misc
@@ -1,0 +1,1 @@
+Moved the `mkdir` command to the top of `pulp-api` script.

--- a/images/assets/pulp-api
+++ b/images/assets/pulp-api
@@ -1,5 +1,9 @@
 #!/bin/bash -x
 
+mkdir -p /var/lib/pulp/media \
+         /var/lib/pulp/assets \
+         /var/lib/pulp/tmp
+
 /usr/bin/wait_on_postgres.py
 
 # Get list of installed plugins via pip
@@ -26,10 +30,6 @@ if [ -n "${PULP_ADMIN_PASSWORD}" ]; then
     /usr/local/bin/pulpcore-manager reset-admin-password --password "${PULP_ADMIN_PASSWORD}"
 fi
 set -x
-
-mkdir -p /var/lib/pulp/media \
-         /var/lib/pulp/assets \
-         /var/lib/pulp/tmp
 
 # NOTE: Due to the Linux dual-stack functionality, this will listen on both IPv4
 # IPv6, even though netstat may seem to indicate it is IPv6 only.


### PR DESCRIPTION
In addition to issue #472 there is a new error with the latest version of Pulp that is impacting `pulp-operator` execution:
https://github.com/pulp/pulp-operator/actions/runs/5256100695/jobs/9496907100#step:13:7425
```
...
  Postgres started!
  + /usr/bin/wait_on_database_migrations.sh
  Checking for database migrations
  SystemCheckError: System check identified some issues:
  
  ERRORS:
  ?: (files.E001) The FILE_UPLOAD_TEMP_DIR setting refers to the nonexistent directory '/var/lib/pulp/tmp'.
  + exec gunicorn pulpcore.content:server --name pulp-content --bind '[::]:24816' --worker-class aiohttp.GunicornWebWorker --timeout 90 --workers 2 --access-logfile -
  Database migrated!
  [2023-06-13 13:33:21 +0000] [1] [INFO] Starting gunicorn 20.1.0
  [2023-06-13 13:33:21 +0000] [1] [INFO] Listening at: http://[::]:24816 (1)
  [2023-06-13 13:33:21 +0000] [1] [INFO] Using worker: aiohttp.GunicornWebWorker
  [2023-06-13 13:33:21 +0000] [15] [INFO] Booting worker with pid: 15
  [2023-06-13 13:33:21 +0000] [16] [INFO] Booting worker with pid: 16
  pulp [None]: asyncio:ERROR: Task exception was never retrieved
  future: <Task finished name='Task-2' coro=<_heartbeat() done, defined at /usr/local/lib/python3.8/site-packages/pulpcore/content/__init__.py:37> exception=ProgrammingError('relation "core_contentappstatus" does not exist\nLINE 1: ...artbeat", "core_contentappstatus"."versions" FROM "core_cont...\n                                                             ^')>
  Traceback (most recent call last):
    File "/usr/local/lib/python3.8/site-packages/django/db/backends/utils.py", line 89, in _execute
      return self.cursor.execute(sql, params)
    File "/usr/local/lib/python3.8/site-packages/psycopg/cursor.py", line 723, in execute
      raise ex.with_traceback(None)
  psycopg.errors.UndefinedTable: relation "core_contentappstatus" does not exist
  LINE 1: ...artbeat", "core_contentappstatus"."versions" FROM "core_cont...
                                                               ^
...
```
fixes: #472