### PR TITLE
Fix CI failing to compose-up for 2 reasons

### DIFF
--- a/.github/workflows/pulp_images.yml
+++ b/.github/workflows/pulp_images.yml
@@ -242,7 +242,11 @@ jobs:
             # Reuse the folders from the s6 mode tests
             FILE="docker-compose.folders.yml"
             # We'll pull the web image from a registry since we didn't build it.
-            WEB_TAG="${APP_BRANCH}"
+            if [ "${{ matrix.image_variant }}" == "nightly" ]; then
+              WEB_TAG="nightly"
+            else
+              WEB_TAG="${APP_BRANCH}"
+            fi
           else
             FILE="docker-compose.yml"
             WEB_TAG="${TEMP_APP_TAG}"

--- a/.github/workflows/pulp_images.yml
+++ b/.github/workflows/pulp_images.yml
@@ -186,6 +186,12 @@ jobs:
           echo ::endgroup::
           echo "HTTPIE_CONFIG_DIR=$GITHUB_WORKSPACE/.ci/assets/httpie/" >> $GITHUB_ENV
           pip install podman-compose
+          if [[ $(dpkg-query --showformat='${Version}' --show podman) == "3.4.4+ds1-1ubuntu1.22.04.1" && $(dpkg-query --showformat='${Version}' --show containernetworking-plugins) == "0.9.1+ds1-1" ]]
+          then
+            echo "Working around https://bugs.launchpad.net/ubuntu/+source/libpod/+bug/2024394"
+            curl -O http://archive.ubuntu.com/ubuntu/pool/universe/g/golang-github-containernetworking-plugins/containernetworking-plugins_1.1.1+ds1-1_amd64.deb
+            sudo dpkg -i containernetworking-plugins_1.1.1+ds1-1_amd64.deb
+          fi
         shell: bash
       - name: Build images
         run: |


### PR DESCRIPTION
Fix CI failing to compose-up the nightly s6 images

because it is looking for the non-existing tags of the development branch's web images. It should use "nightly" instead.

[noissue]




 Workaround CI failing due to an ubuntu podman bug
    
 https://bugs.launchpad.net/ubuntu/+source/libpod/+bug/2024394
    
 Workaround will disable itself when no longer needed
    
 [noissue]

