### PR TITLE
Issue #526 BUGFIX - Postgres init - Only match first major number of postgres

### DIFF
--- a/images/s6_assets/init/postgres-init
+++ b/images/s6_assets/init/postgres-init
@@ -13,7 +13,7 @@ export C035="\e[35m"
 export C036="\e[36m"
 export C037="\e[37m"
 
-PGVERSION=$(postgres --version | egrep -o "1[0-9]")
+PGVERSION=$(postgres --version | egrep -o "1[0-9]" | head -n1)
 PGHOME="/var/lib/pgsql"
 PGDATA="${PGHOME}/data"
 PGDATA_OLD="${PGHOME}/data_old"


### PR DESCRIPTION
https://github.com/pulp/pulp-oci-images/issues/526

I'm testing this with a base image of redhat 8.6 - everything works once I modify this line.

`postgres --version` returns:
postgres (PostgreSQL) 13.10

Which the regex matches both the 13 and the 10 and caused postgres init to attempt to update the database version and then fail. Postgres doesn't ever come up and thus pulp doesn't work.

Once I use `| head -n1` to get get the `13` and not the additional `10` in the postgres version, everything works.

<img width="482" alt="Screenshot 2023-07-24 at 10 17 25 AM" src="https://github.com/pulp/pulp-oci-images/assets/7855189/9235ecb1-c289-4ff8-b13b-e569757c9b23">

Using regexr