### PR TITLE
Fix auto-publish task for 3.22 branch

### DIFF
--- a/.ci/scripts/update_ci_branches.py
+++ b/.ci/scripts/update_ci_branches.py
@@ -22,7 +22,7 @@ github_api = "https://api.github.com"
 
 for branch in branches:
     print(f"Updating {branch}")
-    if isfloat(branch) and version.parse(branch) < version.parse("3.23") :
+    if isfloat(branch) and version.parse(branch) < version.parse("3.22") :
         workflow_path = "/actions/workflows/publish_images.yaml/dispatches"
     else:
         workflow_path = "/actions/workflows/pulp_images.yml/dispatches"


### PR DESCRIPTION
This script was not properly calling the publish task for the 3.22 branch. It thought that it was still using the old `publish_images` workflow, but the 3.22 branch already has the new `pulp_images` workflow.