### PR TITLE
Fix buildah/skopeo (for pulp_container)

### DIFF
--- a/CHANGES/540.bugfix
+++ b/CHANGES/540.bugfix
@@ -1,0 +1,1 @@
+Fix buildah/skopeo (for pulp_container) when pulp is run inside of a container based on RHEL8.8's podman 4.4 or later.

--- a/images/Containerfile.core.base
+++ b/images/Containerfile.core.base
@@ -63,6 +63,7 @@ RUN dnf -y install python38 python38-cryptography python38-devel && \
     dnf -y install sudo && \
     dnf -y install zstd && \
     dnf -y install which && \
+    getcap /usr/bin/newuidmap  | grep cap_setuid || dnf -y reinstall -y shadow-utils && \
     dnf clean all
 
 # Needed to prevent the wrong version of cryptography from being installed,
@@ -79,11 +80,17 @@ RUN pip3 install --upgrade pip setuptools wheel && \
          requests\[use_chardet_on_py3] && \
          rm -rf /root/.cache/pip
 
-RUN sed 's|^#mount_program|mount_program|g' -i /etc/containers/storage.conf
 
 RUN groupadd -g 700 --system pulp
 RUN useradd -d /var/lib/pulp --system -u 700 -g pulp pulp
-RUN usermod --add-subuids 100000-165535 --add-subgids 100000-165535 pulp
+
+# Rootless podman inside rootless podman/docker
+# https://www.redhat.com/sysadmin/podman-inside-container
+RUN sed 's|^#mount_program|mount_program|g' -i /etc/containers/storage.conf
+RUN usermod --add-subuids 10000-65535 --add-subgids 10000-65535 pulp
+VOLUME /var/lib/containers
+RUN mkdir -p /var/lib/pulp/.local/share/containers && chown -R pulp:pulp /var/lib/pulp/.local
+VOLUME /var/lib/pulp/.local/share/containers
 
 RUN mkdir -p /database \
              /etc/nginx/pulp \

--- a/images/s6_assets/pulp_tests.sh
+++ b/images/s6_assets/pulp_tests.sh
@@ -52,5 +52,8 @@ podman exec -u pulp -i pulp bash -c "cat > /var/lib/pulp/scripts/sign_deb_releas
 podman exec -u pulp pulp chmod a+rx /var/lib/pulp/scripts/sign_deb_release.sh
 podman exec -u pulp pulp bash -c "pulpcore-manager add-signing-service --class deb:AptReleaseSigningService sign_deb_release /var/lib/pulp/scripts/sign_deb_release.sh 'Pulp QE'"
 
+# Test buildah for pulp_container's usage
+podman exec -u pulp pulp podman build https://github.com/openshift-examples/web.git
+
 echo "Run all CLI tests"
 make test

--- a/images/s6_assets/test.sh
+++ b/images/s6_assets/test.sh
@@ -10,6 +10,11 @@ cleanup() {
 }
 trap cleanup EXIT
 
+# "--security-opt unmask=none" needed on rhel8 for `podman run`, but we only
+# ever need to run buildah & skopeo (pulp_container does)
+# "--device /dev/net/tun" needed for `podman run`, but we only ever need to run
+# buildah & skopeo (pulp_container does)
+
 start_container_and_wait() {
   podman run --detach \
              --publish 8080:$port \


### PR DESCRIPTION
Fix buildah/skopeo (for pulp_container) when pulp
    
is run inside of a container based on RHEL 8.8's podman 4.4 or later.
    
fixes: #540
