### PR TITLE
Configure SSL if variable is capitalized or not

### DIFF
--- a/images/s6_assets/init/nginx
+++ b/images/s6_assets/init/nginx
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ "${PULP_HTTPS}" = "true" ]; then
+if [ "${PULP_HTTPS,,}" = "true" ]; then
   cp -avr /nginx/ssl_nginx.conf /etc/nginx/nginx.conf
 else
   cp -avr /nginx/nginx.conf /etc/nginx/nginx.conf


### PR DESCRIPTION
When using ansible-podman-collections to create the multi-process images, boolean environment are capitalized.
So this is workaround until
https://github.com/containers/ansible-podman-collections/issues/648 is fixed.