### PR TITLE
Fixed buildah/skopeo failing with images

### DIFF
--- a/CHANGES/555.bugfix
+++ b/CHANGES/555.bugfix
@@ -1,0 +1,1 @@
+Fixed buildah/skopeo failing with images containing files owned by the nobody or nfsnobody users on UIDs/GIDs 65534 or 65535.

--- a/images/Containerfile.core.base
+++ b/images/Containerfile.core.base
@@ -87,7 +87,12 @@ RUN useradd -d /var/lib/pulp --system -u 700 -g pulp pulp
 # Rootless podman inside rootless podman/docker
 # https://www.redhat.com/sysadmin/podman-inside-container
 RUN sed 's|^#mount_program|mount_program|g' -i /etc/containers/storage.conf
-RUN usermod --add-subuids 10000-65535 --add-subgids 10000-65535 pulp
+# We modified the example so that we have a UID range of upto 65535.
+# Because, for example, the image docker.io/library/busybox actually uses the user nobody(65534) for
+# /home rather than the traditional nobody/nfsnbody usage (not an owner on a permanent filesystem.)
+# This does however mean that a user must have a UID range for the pulp container of at least 75535
+# large (UID 0 is in addition), contrary to many examples out there that are only 65536 large.
+RUN usermod --add-subuids 10000-75534 --add-subgids 10000-75534 pulp
 VOLUME /var/lib/containers
 RUN mkdir -p /var/lib/pulp/.local/share/containers && chown -R pulp:pulp /var/lib/pulp/.local
 VOLUME /var/lib/pulp/.local/share/containers

--- a/images/s6_assets/pulp_tests.sh
+++ b/images/s6_assets/pulp_tests.sh
@@ -53,7 +53,11 @@ podman exec -u pulp pulp chmod a+rx /var/lib/pulp/scripts/sign_deb_release.sh
 podman exec -u pulp pulp bash -c "pulpcore-manager add-signing-service --class deb:AptReleaseSigningService sign_deb_release /var/lib/pulp/scripts/sign_deb_release.sh 'Pulp QE'"
 
 # Test buildah for pulp_container's usage
+podman exec -u pulp pulp podman system migrate
 podman exec -u pulp pulp podman build https://github.com/openshift-examples/web.git
+# Test skopeo for pulp_container's usage with an image with the nobody uid 65534
+# (And the image that pulp_container CI actually tests with)
+podman exec -u pulp pulp podman pull docker.io/library/busybox
 
 echo "Run all CLI tests"
 make test

--- a/images/s6_assets/test.sh
+++ b/images/s6_assets/test.sh
@@ -57,6 +57,12 @@ else
   pulp_https=true
 fi
 
+# Configure the GHA host for buildah/skopeo running within the pulp container
+# Default range is 165536-231071, 64K long
+# sudo usermod --add-subuids 231072-241071 --add-subgid 231072-241071 runner
+sudo sed -i "s\runner:165536:65536\runner:165536:75536\g" /etc/subuid /etc/subgid
+podman system migrate
+
 mkdir -p settings pulp_storage pgsql containers
 echo "CONTENT_ORIGIN='$scheme://localhost:8080'" >> settings/settings.py
 echo "ALLOWED_EXPORT_PATHS = ['/tmp']" >> settings/settings.py


### PR DESCRIPTION
containing files owned by the nobody or nfsnobody users on UIDs/GIDs 65534 or 65535.

Requires updating pulp-container (or plugin-template) with the
GHA host subuid/subgid change (after merge and image publish.)


fixes: #555