### PR TITLE
Fix manifest not being created correctly for multi-arch build

### DIFF
--- a/.github/workflows/pulp_images.yml
+++ b/.github/workflows/pulp_images.yml
@@ -366,7 +366,7 @@ jobs:
                 fi
               fi
               for tag in $tags; do
-                podman manifest create ${registry}/pulp/${image_name_looped}:${tag} pulp/${image_name_looped}:${TEMP_BASE_TAG}-amd64 pulp/${image_name_looped}:${TEMP_BASE_TAG}-arm64
+                podman manifest create ${registry}/pulp/${image_name_looped}:${tag} containers-storage:localhost/pulp/${image_name_looped}:${TEMP_BASE_TAG}-amd64 containers-storage:localhost/pulp/${image_name_looped}:${TEMP_BASE_TAG}-arm64
                 podman manifest push --all ${registry}/pulp/${image_name_looped}:${tag}
               done
             done


### PR DESCRIPTION
I've seen the latest issue about the manifest not being created after merging #562 and wanted to provide a fix for that. I'm sorry about pipelines that are still failing.

As that action is not running when in a PR, I've created an additional branch on my fork where this change is tested, without pushing the manifest to the repository.
Please wait for [this run](https://github.com/StopMotionCuber/pulp-oci-images/actions/runs/6959530178) to successfully create the manifests in the "Test manifest build" step until merging