### PR TITLE
Fix pulp CI tests failing for 2 different reasons

### DIFF
--- a/CHANGES/584.bugfix
+++ b/CHANGES/584.bugfix
@@ -1,0 +1,1 @@
+Fix pulp CI tests failing with "pulp: command not found"

--- a/CHANGES/588.bugfix
+++ b/CHANGES/588.bugfix
@@ -1,0 +1,1 @@
+Workaround pulp_tests.sh failing to build the latest branch of openshift-examples/web.git

--- a/images/s6_assets/pulp_tests.sh
+++ b/images/s6_assets/pulp_tests.sh
@@ -55,7 +55,12 @@ podman exec -u pulp pulp bash -c "pulpcore-manager add-signing-service --class d
 
 # Test buildah for pulp_container's usage
 podman exec -u pulp pulp podman system migrate
-podman exec -u pulp pulp podman build https://github.com/openshift-examples/web.git
+# This is currently not working due to a bug in it, so workaround below
+# podman exec -u pulp pulp podman build https://github.com/openshift-examples/web.git
+podman exec -u pulp pulp git clone https://github.com/openshift-examples/web.git /tmp/web
+podman exec -u pulp pulp git -C /tmp/web checkout 7a5e95bbf7111f32be27b5fc9bc0070f844a03a3
+podman exec -u pulp pulp podman build /tmp/web
+
 # Test skopeo for pulp_container's usage with an image with the nobody uid 65534
 # (And the image that pulp_container CI actually tests with)
 podman exec -u pulp pulp podman pull docker.io/library/busybox

--- a/images/s6_assets/pulp_tests.sh
+++ b/images/s6_assets/pulp_tests.sh
@@ -21,6 +21,7 @@ else
   cd pulp-cli
 fi
 pip install -r test_requirements.txt || pip install --no-build-isolation -r test_requirements.txt
+pip install pulp-cli
 if [ -e tests/cli.toml ]; then
   mv tests/cli.toml "tests/cli.toml.bak.$(date -R)"
 fi


### PR DESCRIPTION
Fixes: #584

Fixes: #588

Note: Galaxy tests are still failing due to python version, which is a much larger endeavor under way.