### PR TITLE
Add lsof to the base image installs

### DIFF
--- a/images/Containerfile.core.base
+++ b/images/Containerfile.core.base
@@ -62,6 +62,7 @@ RUN dnf -y install python3 python3-cryptography python3-devel && \
     dnf -y install jq && \
     dnf -y install which && \
     dnf -y install rpm-sign && \
+    dnf -y install lsof && \
     getcap /usr/bin/newuidmap  | grep cap_setuid || dnf -y reinstall -y shadow-utils && \
     dnf clean all
 


### PR DESCRIPTION
This line in the plugin template (https://github.com/pulp/plugin_template/blob/main/templates/github/.github/workflows/scripts/before_script.sh.j2#L37) slows the down the CI by 30sec ~ 1min because dnf has to update its indexes before installing. We already have `which` so adding `lsof` will allow us to remove those lines in the plugin_template.