### PR TITLE
Update CI branches

### DIFF
--- a/.ci/scripts/update_ci_branches.py
+++ b/.ci/scripts/update_ci_branches.py
@@ -3,8 +3,6 @@ import requests
 from yaml import safe_load
 from packaging import version
 
-branches = ["3.28", "3.23", "3.22", "3.21", "3.18", "3.16"]
-
 # We use this to check if the version is x,y, like a normal branch.
 def isfloat(num):
     try:
@@ -19,10 +17,19 @@ headers = {
 }
 
 github_api = "https://api.github.com"
+core_template_config = "https://raw.githubusercontent.com/pulp/pulpcore/main/template_config.yml"
+
+request = requests.get(core_template_config)
+if request.status_code != 200:
+    print("Failed to find supported branches")
+    exit(1)
+
+template = safe_load(request.content)
+branches = template.get("supported_release_branches", [])
 
 for branch in branches:
     print(f"Updating {branch}")
-    if isfloat(branch) and version.parse(branch) < version.parse("3.22") :
+    if isfloat(branch) and version.parse(branch) < version.parse("3.22"):
         workflow_path = "/actions/workflows/publish_images.yaml/dispatches"
     else:
         workflow_path = "/actions/workflows/pulp_images.yml/dispatches"


### PR DESCRIPTION
@mikedep333 We have not been creating the release branches for the last ~20 releases. We need to create branches for 3.39 and 3.45. What commits should we use for these branches? I think we should choose commits around their release dates: 3.39 - 10/25/23 , 3.45 - 01/24/24. 