### PR TITLE
Backport #604 to 3.28

### DIFF
--- a/CHANGES/603.bugfix
+++ b/CHANGES/603.bugfix
@@ -1,0 +1,1 @@
+ensure we are using the correct verion of pulp-cli tests

--- a/images/s6_assets/pulp_tests.sh
+++ b/images/s6_assets/pulp_tests.sh
@@ -12,15 +12,26 @@ echo "Base Address: $BASE_ADDR"
 grep "127.0.0.1   pulp" /etc/hosts || echo "127.0.0.1   pulp" | sudo tee -a /etc/hosts
 
 echo "Installing Pulp-CLI"
+pip install pulp-cli
+
+# Retreive installed pulp-cli version
+PULP_CLI_VERSION=$(python3 -c \
+  'import importlib.metadata; \
+   from packaging.version import Version; \
+   print(Version(importlib.metadata.version("pulp-cli")))')
+
+# Checkout git repo for pulp-cli at correct version to fetch tests
 if [ -d pulp-cli ]; then
   cd pulp-cli
-  git fetch origin
-  git reset --hard origin/main
+  git fetch --tags origin
+  git reset --hard $PULP_CLI_VERSION
 else
-  git clone --depth=1 https://github.com/pulp/pulp-cli.git
+  git clone --depth=1 https://github.com/pulp/pulp-cli.git -b "${PULP_CLI_VERSION}"
   cd pulp-cli
 fi
+
 pip install -r test_requirements.txt || pip install --no-build-isolation -r test_requirements.txt
+
 if [ -e tests/cli.toml ]; then
   mv tests/cli.toml "tests/cli.toml.bak.$(date -R)"
 fi

--- a/images/s6_assets/test.sh
+++ b/images/s6_assets/test.sh
@@ -56,6 +56,8 @@ mkdir -p settings pulp_storage pgsql containers
 echo "CONTENT_ORIGIN='$scheme://localhost:8080'" >> settings/settings.py
 echo "ALLOWED_EXPORT_PATHS = ['/tmp']" >> settings/settings.py
 echo "ORPHAN_PROTECTION_TIME = 0" >> settings/settings.py
+# pulp_rpm < 3.25 requires sha1 in allowed checksums
+echo "ALLOWED_CONTENT_CHECKSUMS = ['sha1', 'sha256', 'sha512']" >> settings/settings.py
 
 if [ "$old_image" != "" ]; then
   start_container_and_wait $old_image


### PR DESCRIPTION
Get correct version of pulp-cli tests

(cherry picked from commit b0dd4529fca3ae5f1604fb6af3583384b2e5f197)