### PR TITLE
Fix string quotes in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -200,7 +200,7 @@ jobs:
         with:
           image_names: ${{ env.IMAGES }}
           tags: ${{ env.TAGS }}
-          build_tag: ${{ matrix.image_variant == "nightly" && "nightly" || github.ref_name }}
+          build_tag: ${{ matrix.image_variant == 'nightly' && 'nightly' || github.ref_name }}
 
       - name: Logs
         if: always()


### PR DESCRIPTION
Didn't read the documentation close enough, strings inside expressions **_must_** use single quotes: https://docs.github.com/en/actions/learn-github-actions/expressions#literals