### PR TITLE
Fix reading of unavailable DOMAIN_ENABLED setting

### DIFF
--- a/images/s6_assets/template_nginx.py
+++ b/images/s6_assets/template_nginx.py
@@ -30,7 +30,7 @@ if __name__ == "__main__":
     else:
         values["api_root"] = settings.API_ROOT
         values["content_path"] = settings.CONTENT_PATH_PREFIX
-        values["domain_enabled"] = settings.DOMAIN_ENABLED
+        values["domain_enabled"] = getattr(settings, "DOMAIN_ENABLED", False)
 
     template = Template(args.template_file.read())
     output = template.render(**values)


### PR DESCRIPTION
On older versions of Pulpcore this setting is unknown and should be assumed False.

[noissue]