### PR TITLE
Fix docs links to Certificates and Database Encryption

### DIFF
--- a/CHANGES/632.doc
+++ b/CHANGES/632.doc
@@ -1,0 +1,1 @@
+Fix the links to "Certificates" and "Database Encryption"

--- a/docs/multi-process-images.md
+++ b/docs/multi-process-images.md
@@ -248,9 +248,9 @@ See [Signing Services](signing_script) documentation for more information.
 
 ### Certificates and Keys
 
-Follow the instructions from [certificates](certificates) documentation for more information about how to configure custom certificates.
+Follow the instructions from [certificates](../certificates) documentation for more information about how to configure custom certificates.
 
-Check [database encryption](database-encryption) documentation for more information about the key to encrypt sensitive fields in the database.
+Check [database encryption](../database-encryption) documentation for more information about the key to encrypt sensitive fields in the database.
 
 ### Command to specify
 


### PR DESCRIPTION
Fixes: #632

I tested it locally with `mkdocs serve`