### PR TITLE
Publish the latest tag for the 3.39 pulp-ci-centos

### DIFF
--- a/.github/workflows/pulp_images.yml
+++ b/.github/workflows/pulp_images.yml
@@ -325,6 +325,14 @@ jobs:
               else
                 tags="${BASE_BRANCH} ${BASE_VERSION}"
               fi
+              # Workaround the fact that the latest branch no longer pushes pulp-ci-centos (CentOS 8)
+              # so let's use this 3.39 branch for it.
+              # But let's not set the latest tag for the base image, that is EL9.
+              if [ "$image_name_looped" == "pulp-ci-centos" ]; then
+                if [ "${TEMP_BASE_TAG}" == "3.39" ]; then
+                  tags="${tags} latest"
+                fi
+              fi
               for tag in $tags; do
                 podman manifest create ${registry}/pulp/${image_name_looped}:${tag} containers-storage:localhost/pulp/${image_name_looped}:${TEMP_BASE_TAG}-amd64 containers-storage:localhost/pulp/${image_name_looped}:${TEMP_BASE_TAG}-arm64
                 podman manifest push --all ${registry}/pulp/${image_name_looped}:${tag} ${registry}/pulp/${image_name_looped}:${tag}

--- a/CHANGES/639.bugfix
+++ b/CHANGES/639.bugfix
@@ -1,0 +1,3 @@
+Publish the "latest" tag for pulp-ci-centos (CentOS 8) on the 3.39 branch.
+
+For the 3.39 branch specifically, the last branch on CentOS 8.


### PR DESCRIPTION
So that pulp-ci-centos (EL8) will continue to have a latest tag that points to the newest image.

Fixes: #639