### PR TITLE
Added missing 'pinentry' package

### DIFF
--- a/images/Containerfile.core.base
+++ b/images/Containerfile.core.base
@@ -71,6 +71,7 @@ RUN dnf -y install python${PYTHON_VERSION} python3-cryptography python${PYTHON_V
     dnf -y install which && \
     dnf -y install rpm-sign && \
     dnf -y install lsof && \
+    dnf -y install pinentry && \
     getcap /usr/bin/newuidmap  | grep cap_setuid || dnf -y reinstall -y shadow-utils && \
     dnf clean all
 


### PR DESCRIPTION
This package is required to import GPG keys via e.g. `gpg --import /var/lib/pulp/gpg/ppos_rpm_private.gpg`  inside the image.

Else it will fail with the following error:
```
pulp bash -c 'gpg --import /var/lib/pulp/gpg/ppos_rpm_private.gpg'
gpg: key D6763692AE005CBF: "..." not changed
gpg: key D6763692AE005CBF/D6763692AE005CBF: error sending to agent: No pinentry
gpg: error reading '/var/lib/pulp/gpg/ppos_rpm_private.gpg': No pinentry
gpg: import from '/var/lib/pulp/gpg/ppos_rpm_private.gpg' failed: No pinentry
gpg: Total number processed: 0
gpg:              unchanged: 1
gpg:       secret keys read: 1
```