### PR TITLE
Remove deprecated "update-ca-trust force-enable" call

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,8 @@ jobs:
           podman ps -a
           podman images -a
           podman logs pulp
+          echo "plottin'"
+          cat /var/lib/pgsql/data/log/*.log
           cd images/compose
           podman-compose logs
           podman logs --tail=10000 compose_pulp_api_1

--- a/images/s6_assets/init/certs
+++ b/images/s6_assets/init/certs
@@ -35,8 +35,7 @@ if ! [ -e /etc/pki/tls/certs/pulp_webserver.crt ]; then
   cp /etc/pulp/certs/pulp_webserver.crt /etc/pki/tls/certs/pulp_webserver.crt
   cp /etc/pulp/certs/pulp_webserver.csr /etc/pki/tls/private/pulp_webserver.csr
   cp /etc/pulp/certs/pulp_webserver.key /etc/pki/tls/private/pulp_webserver.key
-  update-ca-trust force-enable
-  update-ca-trust extract
+  update-ca-trust
   cat /etc/pulp/certs/pulp_webserver.crt >> /etc/pki/tls/cert.pem
   echo -e "${PREFIX} ${GREEN}finished adding webserver certificate to the certificate store${ENDCOLOR}"
 fi


### PR DESCRIPTION
According to the docs, it is sufficient just to call "update-ca-trust [extract]" which instructs update-ca-trust to scan the SOURCE CONFIGURATION and produce updated versions of the consolidated configuration files stored below the /etc/pki/ca-trust/extracted directory hierarchy.

https://www.unix.com/man-page/centos/8/update-ca-trust/

[noissue]