### PR TITLE
Fix CI errors

### DIFF
--- a/images/pulp_ci_centos/Containerfile
+++ b/images/pulp_ci_centos/Containerfile
@@ -22,12 +22,12 @@ ENV S6_BEHAVIOUR_IF_STAGE2_FAILS=1
 # https://github.com/just-containers/s6-overlay/issues/467
 ENV S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0
 
-RUN dnf -y install postgresql && \
-    dnf -y install postgresql-contrib && \
-    dnf -y install postgresql-server && \
-    dnf -y install postgresql-upgrade && \
-    dnf -y install nginx && \
-    dnf -y install redis && \
+RUN dnf -y install postgresql \
+      postgresql-contrib \
+      postgresql-server \
+      postgresql-upgrade \
+      nginx \
+      redis && \
     dnf clean all
 
 COPY images/s6_assets/openssl.cnf /etc/ssl/pulp/openssl.cnf

--- a/images/s6_assets/init/certs
+++ b/images/s6_assets/init/certs
@@ -35,8 +35,7 @@ if ! [ -e /etc/pki/tls/certs/pulp_webserver.crt ]; then
   cp /etc/pulp/certs/pulp_webserver.crt /etc/pki/tls/certs/pulp_webserver.crt
   cp /etc/pulp/certs/pulp_webserver.csr /etc/pki/tls/private/pulp_webserver.csr
   cp /etc/pulp/certs/pulp_webserver.key /etc/pki/tls/private/pulp_webserver.key
-  update-ca-trust force-enable
-  update-ca-trust extract
+  update-ca-trust
   cat /etc/pulp/certs/pulp_webserver.crt >> /etc/pki/tls/cert.pem
   echo -e "${PREFIX} ${GREEN}finished adding webserver certificate to the certificate store${ENDCOLOR}"
 fi

--- a/images/s6_assets/init/postgres-prepare
+++ b/images/s6_assets/init/postgres-prepare
@@ -13,6 +13,11 @@ export C035="\e[35m"
 export C036="\e[36m"
 export C037="\e[37m"
 
+if [ ! -d "/var/run/postgresql" ]; then
+  mkdir -p /var/run/postgresql
+  chown postgres:postgres /var/run/postgresql
+fi
+
 PG_ISREADY=1
 while [ "$PG_ISREADY" != "0"  ]; do
   sleep 1


### PR DESCRIPTION
* Remove deprecated "update-ca-trust force-enable" call
* Create the `/var/run/postgresql` directory. In older versions
of postgresql-server package, this directory was created during
package installation. The newer versions are not creating it
anymore (because systemd was supposed to do it) which is breaking
our s6 based images.
* Change a Containerfile RUN instruction to run dnf once (not a fix,
just a little improvement)

[noissue]