### PR TITLE
Fix base image build having a selinux dependency collision

### DIFF
--- a/images/Containerfile.core.base
+++ b/images/Containerfile.core.base
@@ -44,7 +44,7 @@ RUN dnf -y module enable nginx:1.22
 # of dependencies below. For example, drpm-devel.
 RUN dnf -y install python${PYTHON_VERSION} python3-cryptography python${PYTHON_VERSION}-devel && \
     dnf -y install openssl openssl-devel && \
-    dnf -y install openldap-devel && \
+    dnf -y install openldap-devel --exclude selinux* && \
     dnf -y install wget git && \
     dnf -y install python3-psycopg2 && \
     dnf -y install redhat-rpm-config gcc cargo libffi-devel && \
@@ -54,7 +54,7 @@ RUN dnf -y install python${PYTHON_VERSION} python3-cryptography python${PYTHON_V
     dnf -y install libpq-devel && \
     dnf -y install python3-setuptools && \
     dnf -y install swig && \
-    dnf -y install buildah --exclude container-selinux && \
+    dnf -y install podman fuse-overlayfs buildah --exclude container-selinux && \
     dnf -y install xz && \
     dnf -y install libmodulemd-devel && \
     dnf -y install libcomps-devel && \
@@ -64,7 +64,6 @@ RUN dnf -y install python${PYTHON_VERSION} python3-cryptography python${PYTHON_V
     dnf -y install libcurl-devel libxml2-devel sqlite-devel file-devel && \
     dnf -y install ostree-libs ostree && \
     dnf -y install skopeo && \
-    dnf -y install podman && \
     dnf -y install sudo && \
     dnf -y install zstd && \
     dnf -y install jq && \


### PR DESCRIPTION
Honestly have no idea what I am doing, but the error with `sed: File not found` is because buildah was failing to install due to seeing selinux-policy in the system. https://github.com/pulp/pulp-oci-images/actions/runs/10894878722/job/30232255402#step:8:5020

```
Error: 
 Problem: package buildah-2:1.37.2-1.el9.aarch64 from appstream requires containers-common >= 2:1-2, but none of the providers can be installed
  - package containers-common-2:1-13.el9.noarch from appstream requires (container-selinux >= 2:2.162.1 if selinux-policy), but none of the providers can be installed
  - package containers-common-2:1-21.el9.noarch from appstream requires (container-selinux >= 2:2.162.1 if selinux-policy), but none of the providers can be installed
  - package containers-common-2:1-52.el9.aarch64 from appstream requires (container-selinux >= 2:2.162.1 if selinux-policy), but none of the providers can be installed
  - package containers-common-2:1-55.el9.aarch64 from appstream requires (container-selinux >= 2:2.162.1 if selinux-policy), but none of the providers can be installed
  - package containers-common-2:1-61.el9.aarch64 from appstream requires (container-selinux >= 2:2.162.1 if selinux-policy), but none of the providers can be installed
  - package containers-common-2:1-8.el9.noarch from appstream requires (container-selinux >= 2:2.162.1 if selinux-policy), but none of the providers can be installed
  - package containers-common-2:1-90.el9.aarch64 from appstream requires (container-selinux >= 2:2.162.1 if selinux-policy), but none of the providers can be installed
(try to add '--skip-broken' to skip uninstallable packages or '--nobest' to use not only best candidate packages)
  - package containers-common-2:1-91.el9.aarch64 from appstream requires (container-selinux >= 2:2.162.1 if selinux-policy), but none of the providers can be installed
  - problem with installed package selinux-policy-38.1.44-1.el9.noarch
  - cannot install the best candidate for the job
  - package container-selinux-3:2.228.1-1.el9.noarch from appstream is filtered out by exclude filtering
  - package container-selinux-3:2.229.0-1.el9.noarch from appstream is filtered out by exclude filtering
  - package container-selinux-3:2.230.0-1.el9.noarch from appstream is filtered out by exclude filtering
  - package container-selinux-3:2.231.0-1.el9.noarch from appstream is filtered out by exclude filtering
  - package container-selinux-3:2.232.1-1.el9.noarch from appstream is filtered out by exclude filtering
```
After reading this linked article in the containerfile (https://www.redhat.com/sysadmin/podman-inside-container) I guessed we don't want selinux in order to do podman inside podman. So I found an earlier install that was dragging in selinux, openldap-devel, and excluded it from install. Maybe it would be better to switch the order of the installs and have podman/buildah installed first? Would like some suggestions on the best approach.