### PR TITLE
Fix release failing when there were duplicate tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,6 +130,7 @@ jobs:
               tags="${tags} ${NIGHTLY_VERSION} ${NIGHTLY_BRANCH} latest"
             fi
           fi
+          tags=$(echo "${tags}" | xargs -n1 | sort -u | xargs)
           echo "Set tags to: $tags"
           echo "TAGS=${tags}" >> $GITHUB_ENV
 
@@ -200,6 +201,7 @@ jobs:
           else
             tags="nightly"
           fi
+          tags=$(echo "${tags}" | xargs -n1 | sort -u | xargs)
           echo "Going to publish with tags: $tags"
           echo "TAGS=${tags}" >> $GITHUB_ENV
 


### PR DESCRIPTION
We can get duplicate tags right after we do a release and not immediately merge the version bump in pulpcore. Nightly will then have the same y-version as the latest release which creates duplicate tags in our tagging logic. Now we de-dup the tags before publishing.