### PR TITLE
Delete base-images cache entry on rebuild

### DIFF
--- a/.github/actions/base_images/action.yml
+++ b/.github/actions/base_images/action.yml
@@ -102,6 +102,14 @@ runs:
         gzip base-images.tar
       shell: bash
 
+    - name: Clear cache for next upload
+      if: env.BUILD_IMAGES && steps.cache.outputs.cache-hit == 'true'
+      run: |
+        echo "Deleting existing cache for ${{ steps.hash_key.outputs.base_cache_key }}"
+        gh extension install actions/gh-actions-cache
+        gh actions-cache delete "base-images=${{ steps.hash_key.outputs.base_cache_key }}" --R ${{ github.repository }} -B ${{ github.ref }} --confirm
+      shell: bash
+
     - name: Cache podman images
       if: env.BUILD_IMAGES
       uses: actions/cache/save@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,8 @@ jobs:
       - name: Build App Image
         id: build_image
         uses: "./.github/actions/build_image"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           image_name: ${{ matrix.image_name }}
           image_variant: "stable"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,8 @@ jobs:
       - name: Build base images
         id: build_base_images
         uses: "./.github/actions/base_images"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           python_version: ${{ env.PYTHON_VERSION }}
 


### PR DESCRIPTION
So now that we are using the cache between different runs to check if we need to rebuild the base-images, we need to delete the existing entry when a rebuild occurs since the cache action doesn't replace the existing entry upon reupload. 