### PR TITLE
Restrain podman-compose==1.1.0 for tests to deal with upstream bug

### DIFF
--- a/.github/actions/test_image/action.yml
+++ b/.github/actions/test_image/action.yml
@@ -15,7 +15,8 @@ runs:
     - name: Install httpie and podman-compose
       run: |
         echo "HTTPIE_CONFIG_DIR=$GITHUB_WORKSPACE/.ci/assets/httpie/" >> $GITHUB_ENV
-        pip install httpie podman-compose
+        # Constrain while bug is present: https://github.com/containers/podman-compose/issues/1059
+        pip install httpie podman-compose==1.1.0
       shell: bash
 
     - name: Test image with upgrade in s6 mode (pulp)


### PR DESCRIPTION
This affects latest, 3.63 & 3.49. It wasn't showing up on latest because we don't run tests for that runner, when I disabled tests for the nightly build (from main) I also ended up disabling tests for the latest build (from PyPI). I'll add back the tests for latest from PyPI scenario in the next PR.