### PR TITLE
Add post build step to label images with extra metadata

### DIFF
--- a/.github/actions/build_image/action.yml
+++ b/.github/actions/build_image/action.yml
@@ -69,7 +69,7 @@ runs:
       shell: bash
 
     - name: Set hash key
-      run: echo "VERSIONKEY=versions-${{ github.ref_name }}=${{ hashFiles(format('images/{0}/stable/**', inputs.image_name)) }}" >> $GITHUB_ENV
+      run: echo "VERSIONKEY=versions-${{ github.ref_name }}=${{ hashFiles(format('images/{0}/{1}/**', inputs.image_name, inputs.image_variant)) }}" >> $GITHUB_ENV
       shell: bash
 
     - name: Restore last builds versions from cache
@@ -136,6 +136,22 @@ runs:
         echo "app_version=${app_version}" >> "$GITHUB_OUTPUT"
         echo "app_branch=${app_branch}" >> "$GITHUB_OUTPUT"
         cat versions.freeze
+      shell: bash
+
+    - name: Label image with metadata
+      run: |
+        packages=$(podman run --pull=never pulp/${{ inputs.image_name }}:ci-amd64 bash -c "pip3 list --format json")
+        plugin_versions=$(echo $packages | jq -r '.[] | select(.name | contains("pulp")) | .name + "==" + .version')
+        postgres=$(podman run --pull=never pulp/${{ inputs.image_name }}:ci-amd64 bash -c "postgres --version | sed -n -e 's/postgres (PostgreSQL) //p'")
+        python_version=$(podman run --pull=never pulp/${{ inputs.image_name }}:ci-amd64 bash -c "python3 --version | sed -n -e 's/Python //p'")
+        files_hash="${{ hashFiles(format('images/{0}/{1}/**', inputs.image_name, inputs.image_variant), 'images/Containerfile.core.base', 'images/pulp_ci_centos/Containerfile', 'images/assets/**', 'images/s6_assets/**') }}"
+
+        for ARCH in arm64 amd64
+        do
+          tag="pulp/${{ inputs.image_name }}:ci-${ARCH}"
+          echo "FROM ${tag}" | podman build --pull=false --platform linux/${ARCH} --format docker --label "org.pulp.plugins=${plugin_versions}" --label "org.pulp.postgres-version=${postgres}" --label "org.pulp.python-version=${python_version}" --label "org.pulp.containerfiles-hash=${files_hash}" --tag ${tag} -
+        done
+        podman image inspect pulp/${{ inputs.image_name }}:ci-amd64 --format='{{ .Config.Labels }}'
       shell: bash
 
     - name: Clear cache for next upload


### PR DESCRIPTION
I don't like the versions.freeze cache business I am currently doing to optimize when to build. So instead I am going to bake the versions into the label metadata of the image and then use the docker apis to get the info at build time. Here is how the metadata looks:

```
{
  "io.buildah.version": "1.23.1",
  "org.label-schema.build-date": "20240924",
  "org.label-schema.license": "GPLv2",
  "org.label-schema.name": "CentOS Stream 9 Base Image",
  "org.label-schema.schema-version": "1.0",
  "org.label-schema.vendor": "CentOS",
  "org.pulp.plugins": "pulp-ansible==0.22.1\npulp-certguard==1.8.0\npulp-container==2.21.0\npulp-deb==3.3.1\npulp-file==1.16.0\npulp-gem==0.6.1\npulp-glue==0.26.0\npulp-glue-gem==0.5.1\npulp-maven==0.8.1\npulp-ostree==2.4.3\npulp-python==3.12.3\npulp-rpm==3.27.1\npulpcore==3.61.0",
  "org.pulp.postgres-version": "13.16",
  "org.pulp.python-version": "3.13.1"
}
```

Let me know what other metadata we should include.