### PR TITLE
Properly download the correct s6 overlay per machine arch

### DIFF
--- a/images/pulp_ci_centos/Containerfile
+++ b/images/pulp_ci_centos/Containerfile
@@ -2,8 +2,7 @@ ARG FROM_TAG="latest"
 FROM pulp/base:${FROM_TAG}
 # https://ryandaniels.ca/blog/docker-dockerfile-arg-from-arg-trouble/
 
-RUN curl -Ls https://github.com/just-containers/s6-overlay/releases/download/v3.1.6.2/s6-overlay-x86_64.tar.xz | tar xvJ -C /
-RUN curl -Ls https://github.com/just-containers/s6-overlay/releases/download/v3.1.6.2/s6-overlay-aarch64.tar.xz | tar xvJ -C /
+RUN curl -Ls "https://github.com/just-containers/s6-overlay/releases/download/v3.1.6.2/s6-overlay-$(arch).tar.xz" | tar xvJ -C /
 RUN curl -Ls https://github.com/just-containers/s6-overlay/releases/download/v3.1.6.2/s6-overlay-noarch.tar.xz | tar xvJ -C /
 RUN curl -Ls https://github.com/just-containers/s6-overlay/releases/download/v3.1.6.2/s6-overlay-symlinks-noarch.tar.xz | tar xvJ -C /
 RUN curl -Ls https://github.com/just-containers/s6-overlay/releases/download/v3.1.6.2/s6-overlay-symlinks-arch.tar.xz | tar xvJ -C /


### PR DESCRIPTION
The last change was making it so that the ARM s6 files were the last ones extracted which is why the container wasn't working no more (at least when running on x86).