### PR TITLE
Enable nginx listening to IPv6 if available

### DIFF
--- a/CHANGES/595.feature
+++ b/CHANGES/595.feature
@@ -1,0 +1,1 @@
+Enable nginx listening to IPv6 if available

--- a/images/s6_assets/nginx.conf.j2
+++ b/images/s6_assets/nginx.conf.j2
@@ -1,4 +1,3 @@
-# TODO: Support IPv6.
 # TODO: Maybe serve multiple `location`s, not just one.
 
 # The "nginx" package on fedora creates this user and group.
@@ -22,17 +21,17 @@ http {
     types_hash_max_size 4096;
 
     upstream pulp-content {
-         server 127.0.0.1:24816;
+         server {{ '[::1]' if has_ipv6 else '127.0.0.1' }}:24816;
     }
 
     upstream pulp-api {
-         server 127.0.0.1:24817;
+         server {{ '[::1]' if has_ipv6 else '127.0.0.1' }}:24817;
     }
 
     server {
         # Gunicorn docs suggest the use of the "deferred" directive on Linux.
         {% if https | default(false) -%}
-        listen 443 default_server deferred ssl;
+        listen {{ '[::]:' if has_ipv6 }}443 default_server{{ ' ipv6only=off' if has_ipv6 }} deferred ssl;
 
         ssl_certificate /etc/pulp/certs/pulp_webserver.crt;
         ssl_certificate_key /etc/pulp/certs/pulp_webserver.key;
@@ -48,7 +47,7 @@ http {
         # HSTS (ngx_http_headers_module is required) (15768000 seconds = 6 months)
         add_header Strict-Transport-Security max-age=15768000;
         {%- else -%}
-        listen 80 default_server deferred;
+        listen {{ '[::]:' if has_ipv6 }}80 default_server{{ ' ipv6only=off' if has_ipv6 }} deferred;
         {%- endif %}
         server_name $hostname;
 
@@ -140,7 +139,7 @@ http {
     }
     {%- if https | default(false) %}
     server {
-        listen 80 default_server;
+        listen {{ '[::]:' if has_ipv6 }}80 default_server{{ ' ipv6only=off' if has_ipv6 }};
         server_name _;
         return 301 https://$host$request_uri;
     }

--- a/images/s6_assets/template_nginx.py
+++ b/images/s6_assets/template_nginx.py
@@ -3,6 +3,7 @@ import json
 import os
 import django
 from django.core.exceptions import AppRegistryNotReady, ImproperlyConfigured
+from pulpcore.app.netutil import has_ipv6
 
 from jinja2 import Template
 
@@ -19,6 +20,7 @@ if __name__ == "__main__":
     ui = os.getenv("PULP_UI", "false")
     values = {
         "https": https.lower() == "true",
+        "has_ipv6": has_ipv6(),
         "api_root": "/pulp/",
         "content_path": "/pulp/content/",
         "domain_enabled": False,


### PR DESCRIPTION
Issue #595 was closed to early.

This is the required nginx template change to use IPv4 or IPV6 listeners depending on the system capabilities.

Attention: this PR requires a pulpcore version including the netutil.has_ipv6 function from https://github.com/pulp/pulpcore/pull/6594

