### PR TITLE
Remove unused packages in the base image

### DIFF
--- a/images/Containerfile.core.base
+++ b/images/Containerfile.core.base
@@ -35,16 +35,13 @@ RUN dnf -y module enable nginx:1.22
 # glibc-langpack-en is needed to provide the en_US.UTF-8 locale, which Pulp
 # seems to need.
 # cairo/gobject are needed for PyGObject, which pulp_ostree requires
-RUN dnf -y install python3.9 python3-cryptography python3.9-devel && \
+RUN dnf -y install python3.9 python3.9-devel && \
     dnf -y install openssl openssl-devel && \
     dnf -y install openldap-devel --exclude selinux* && \
     dnf -y install wget git && \
-    dnf -y install python3-psycopg2 && \
-    dnf -y install redhat-rpm-config gcc cargo libffi-devel && \
+    dnf -y install gcc libffi-devel && \
     dnf -y install glibc-langpack-en && \
-    dnf -y install python3-libcomps && \
     dnf -y install libpq-devel && \
-    dnf -y install python3-setuptools && \
     dnf -y install podman fuse-overlayfs buildah --exclude container-selinux && \
     dnf -y install cairo-devel gobject-introspection-devel cairo-gobject-devel && \
     dnf -y install ostree-libs ostree && \


### PR DESCRIPTION
This should trim 600 MB (install size) off the images, most of it from removing installing rust (cargo was just hanging out in our install list). The python system packages shouldn't be necessary, pip can install them, also they will be useless once we upgrade to 3.11. 

After this the next biggest packages are gcc, podman, buildah. gcc is needed to build three python dependencies that are only available as sdists: `rhsm`, `python-ldap` (from django-auth-ldap), and `PyGObject `(from pulp-ostree). The cairo & gobject rpms are also needed to build PyGObject. If we could somehow get these packages to wheels then we could shave off another 150 MB installed size.