### PR TITLE
Fix nightly release flow and missing publish

### DIFF
--- a/.github/actions/base_images/action.yml
+++ b/.github/actions/base_images/action.yml
@@ -37,6 +37,7 @@ runs:
           config=$(oras manifest fetch-config --platform linux/amd64 ghcr.io/pulp/pulp-ci-centos9:${branch} | jq -r '.config.Labels')
           latest_hash=$(echo "${config}" | jq -r '."org.pulp.basefiles-hash"')
           build=true
+          echo "Checking hash for ${branch}: ${latest_hash}"
           if [[ "${latest_hash}" == "${HASH}" ]]; then
             if podman run ghcr.io/pulp/pulp-ci-centos9:${branch} bash -c "dnf check-upgrade"; then
               echo "No base images rebuild needed :)"

--- a/.github/actions/publish_images/action.yml
+++ b/.github/actions/publish_images/action.yml
@@ -52,7 +52,7 @@ runs:
       run: |
         for image in ${{ inputs.image_names }}; do
           echo "Create manifest for ${image}"
-          podman manifest create pulp/${image}:ci containers-storage:localhost/pulp/${image}:ci-arm64 containers-storage:localhost/pulp/${image}:ci-amd64
+          podman manifest create pulp/${image}:ci containers-storage:pulp/${image}:ci-arm64 containers-storage:pulp/${image}:ci-amd64
           for registry in ghcr.io docker.io quay.io; do
             echo "Pushing image to ${registry}"
             for tag in ${{ inputs.tags }}; do

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,6 +87,7 @@ jobs:
 
   build-and-test-images:
     needs: base
+    continue-on-error: ${{ matrix.image_variant == 'nightly' }}
     strategy:
       fail-fast: false
       matrix:
@@ -170,7 +171,9 @@ jobs:
           if [[ ${{ matrix.image_variant }} == "stable" ]]; then
             TAG="${{ steps.app_version.outputs.stable_app_version }}-$ARCH"
           else
-            TAG="nightly-$ARCH"
+            # Nightly never rebuilds the base images, but always rebuilds the app images
+            # So set tag to latest to ensure the base images are pulled correctly
+            TAG="latest-$ARCH"
           fi
           echo "TAG=${TAG}" >> $GITHUB_ENV
           echo "ARCH=${ARCH}" >> $GITHUB_ENV
@@ -198,6 +201,7 @@ jobs:
           else
             image_names="${image_names} ghcr.io/pulp/pulp:${trimmed_tag}"
           fi
+          echo "Image names: ${image_names}"
           echo "image_names=${image_names}" >> $GITHUB_ENV
 
       - name: Set output of repo digests of uploaded images
@@ -210,6 +214,7 @@ jobs:
             # This takes advantage of the fact that skopeo will choose the correct platform for the image
             repo_digests="${repo_digests} $(skopeo inspect --format='{{ .Digest }}' docker://${img} )"
           done
+          echo "Repo digests: ${repo_digests}"
           echo "${{ matrix.image_variant }}_${ARCH}=${repo_digests}" >> $GITHUB_OUTPUT
 
       - name: Logs
@@ -240,6 +245,19 @@ jobs:
         image_variant: ${{ fromJSON(needs.base.outputs.image_variants) }}
     steps:
       - uses: actions/checkout@v4
+
+      # Nightly is allowed to fail the build step, so check if we need to publish
+      - name: Check nightly passed
+        if: ${{ matrix.image_variant == 'nightly' }}
+        run: |
+          arm=(${{ needs.build-and-test-images.outputs.nightly_arm }})
+          amd=(${{ needs.build-and-test-images.outputs.nightly_amd }})
+          if [[ ${#arm[@]} -ne 8 || ${#amd[@]} -ne 8 ]]; then
+            echo "Nightly build failed, check previous steps"
+            echo "arm digests: ${arm[@]}"
+            echo "amd digests: ${amd[@]}"
+            exit 1
+          fi
 
       # Merging the arm & amd images together and determining if they need to be published
       - name: Get previous output
@@ -294,6 +312,7 @@ jobs:
             podman tag "ghcr.io/pulp/pulp@${pulp_digests[1]}" pulp/pulp:ci-amd64
             images="${images} pulp"
           fi
+          podman images -a
           echo "Images to publish: $images"
           echo "IMAGES=${images}" >> $GITHUB_ENV
 


### PR DESCRIPTION
Couple issues to fix here:

1. The newly built images were not getting published. The publish action takes the arm & amd images and packages them together into a manifest list to push to the registries. When grabbing the two images we used `container-storage:localhost/pulp/{image}:ci-{arch}`, since when you build an image it gets auto tagged with the `localhost/` prefix. However, now that the publish step is in a different job and we are pulling down the images and retagging them the `localhost/` doesn't get applied so it seems the `podman manifest create` fails to find them.
2. The nightly release logic has been updated to reflect the new build logic: nightly never rebuilds the base images, it always uses latest, but it will always builds the app images. So the logic now accounts for this distinction when preparing to pass the images to the publish step.
3. Nightly can now fail without blocking the publishing of the stable images. Now that publish is a separate job it is reliant on the build-and-test job completing successfully, each of the four variants, before executing. We don't want nightly failing to build to stop us from publishing stable if it completely successfully. 
4. More logging to make sure behavior is easier to reason through.