### PR TITLE
Undo publish change, fix nightly logic

### DIFF
--- a/.github/actions/publish_images/action.yml
+++ b/.github/actions/publish_images/action.yml
@@ -52,7 +52,7 @@ runs:
       run: |
         for image in ${{ inputs.image_names }}; do
           echo "Create manifest for ${image}"
-          podman manifest create pulp/${image}:ci containers-storage:pulp/${image}:ci-arm64 containers-storage:pulp/${image}:ci-amd64
+          podman manifest create pulp/${image}:ci containers-storage:localhost/pulp/${image}:ci-arm64 containers-storage:localhost/pulp/${image}:ci-amd64
           for registry in ghcr.io docker.io quay.io; do
             echo "Pushing image to ${registry}"
             for tag in ${{ inputs.tags }}; do

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,9 +171,7 @@ jobs:
           if [[ ${{ matrix.image_variant }} == "stable" ]]; then
             TAG="${{ steps.app_version.outputs.stable_app_version }}-$ARCH"
           else
-            # Nightly never rebuilds the base images, but always rebuilds the app images
-            # So set tag to latest to ensure the base images are pulled correctly
-            TAG="latest-$ARCH"
+            TAG="nightly-$ARCH"
           fi
           echo "TAG=${TAG}" >> $GITHUB_ENV
           echo "ARCH=${ARCH}" >> $GITHUB_ENV
@@ -186,7 +184,12 @@ jobs:
             podman push pulp/pulp-ci-centos9:ci ghcr.io/pulp/pulp-ci-centos9:${TAG}
             image_names="ghcr.io/pulp/base:${TAG} ghcr.io/pulp/pulp-ci-centos9:${TAG}"
           else
-            image_names="ghcr.io/pulp/base:${trimmed_tag} ghcr.io/pulp/pulp-ci-centos9:${trimmed_tag}"
+            if [[ ${{ matrix.image_variant }} == "nightly" ]]; then
+              # Nightly never rebuilds the base images so there isn't a nightly tag to pull from
+              image_names="ghcr.io/pulp/base:latest-${ARCH} ghcr.io/pulp/pulp-ci-centos9:latest-${ARCH}"
+            else
+              image_names="ghcr.io/pulp/base:${trimmed_tag} ghcr.io/pulp/pulp-ci-centos9:${trimmed_tag}"
+            fi
           fi
           if [[ ${{ steps.build_pulp_minimal_image.outputs.rebuilt_images }} == "true" ]]; then
             podman push pulp/pulp-minimal:ci ghcr.io/pulp/pulp-minimal:${TAG}


### PR DESCRIPTION
Ok, the latest run gave some interesting info: https://github.com/pulp/pulp-oci-images/actions/runs/18761033143/job/53527402366#step:5:425

My assumption about the `localhost/` prefix was wrong. It's still there even if we pull and retag, so I'm undoing that change. Not sure why the original run that didn't publish happened though (https://github.com/pulp/pulp-oci-images/actions/runs/18727980553/job/53423774152#step:6:97). It's possible this revert will make it still fail to publish while reporting that it did. A successful publish has more logs showing the blobs being uploaded: https://github.com/pulp/pulp-oci-images/actions/runs/18702581200/job/53335207305#step:6:99

And again I looked over the nightly logic and reworked it once more to be located to the area that is special, choosing the correct base images to pull.