### PR TITLE
Fix tags not being passed to publish step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -333,7 +333,7 @@ jobs:
           fi
           tags=$(echo "${tags}" | xargs -n1 | sort -u | xargs)
           echo "Set tags to: $tags"
-          echo "TAGS=${tags}" >> $GITHUB_OUTPUT
+          echo "TAGS=${tags}" >> $GITHUB_ENV
 
       - name: Publish images
         if: ${{ env.IMAGES }}


### PR DESCRIPTION
This one was just plain silly. I put the tags into the wrong context, see line 343, and that is why none of the images were being published, they had no tags!