### PR TITLE
Fix wrong tags for nightly base image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -186,7 +186,7 @@ jobs:
           else
             if [[ ${{ matrix.image_variant }} == "nightly" ]]; then
               # Nightly never rebuilds the base images so there isn't a nightly tag to pull from
-              image_names="ghcr.io/pulp/base:latest-${ARCH} ghcr.io/pulp/pulp-ci-centos9:latest-${ARCH}"
+              image_names="ghcr.io/pulp/base:latest ghcr.io/pulp/pulp-ci-centos9:latest"
             else
               image_names="ghcr.io/pulp/base:${trimmed_tag} ghcr.io/pulp/pulp-ci-centos9:${trimmed_tag}"
             fi


### PR DESCRIPTION
Another simple fix. The good thing is last nights run showed that the nightly continue on error is working correctly and the stable images were published! The second purpose of this is to test the rebuild logic. The base images should only rebuild when there is a change in the base containerfiles or they have a package that needs updating, so going to watch their build step here to see that it gets skipped and uses last night's build. The app images always gets rebuilt on PRs, but once merge it will only get built when there is a new pulpcore or plugin version, so we should see it not get built there.