### PR TITLE
Remove unneeded libpq-devel install

### DIFF
--- a/images/Containerfile.core.base
+++ b/images/Containerfile.core.base
@@ -41,7 +41,6 @@ RUN dnf -y install python3.11 python3.11-pip python3.11-devel && \
     dnf -y install wget git && \
     dnf -y install gcc libffi-devel && \
     dnf -y install glibc-langpack-en && \
-    dnf -y install libpq-devel && \
     dnf -y install podman fuse-overlayfs buildah --exclude container-selinux && \
     dnf -y install cairo-devel gobject-introspection-devel cairo-gobject-devel && \
     dnf -y install ostree-libs ostree && \


### PR DESCRIPTION
This shouldn't be needed, but mainly it's interfering with the CI optimization code since it keeps showing up as an obsolete package after installing postgres16 therefore preventing the `dnf check-upgrade` command from returning 0.