### PR TITLE
Fix building S6 arm images [3.63]

### DIFF
--- a/images/pulp_ci_centos/Containerfile
+++ b/images/pulp_ci_centos/Containerfile
@@ -2,7 +2,7 @@ ARG FROM_TAG="latest"
 FROM pulp/base:${FROM_TAG}
 # https://ryandaniels.ca/blog/docker-dockerfile-arg-from-arg-trouble/
 
-RUN curl -Ls https://github.com/just-containers/s6-overlay/releases/download/v3.1.6.2/s6-overlay-x86_64.tar.xz | tar xvJ -C /
+RUN curl -Ls "https://github.com/just-containers/s6-overlay/releases/download/v3.1.6.2/s6-overlay-$(arch).tar.xz" | tar xvJ -C /
 RUN curl -Ls https://github.com/just-containers/s6-overlay/releases/download/v3.1.6.2/s6-overlay-noarch.tar.xz | tar xvJ -C /
 RUN curl -Ls https://github.com/just-containers/s6-overlay/releases/download/v3.1.6.2/s6-overlay-symlinks-noarch.tar.xz | tar xvJ -C /
 RUN curl -Ls https://github.com/just-containers/s6-overlay/releases/download/v3.1.6.2/s6-overlay-symlinks-arch.tar.xz | tar xvJ -C /


### PR DESCRIPTION
This probably needs to be backported to our other supported versions.