### PR TITLE
fix: include UI in stable ref builds, fix conditions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,7 +123,7 @@ jobs:
         with:
           image_name: "pulp-minimal"
           image_variant: ${{ matrix.image_variant }}
-          latest_ui: ${{ github.base_ref == 'latest' }}
+          latest_ui: ${{ github.base_ref == 'latest' || github.ref_name == 'latest' }}
           rebuilt_base_images: ${{ steps.build_base_images.outputs.rebuilt_images }}
 
       - name: Build pulp image
@@ -132,7 +132,7 @@ jobs:
         with:
           image_name: "pulp"
           image_variant: ${{ matrix.image_variant }}
-          latest_ui: ${{ github.base_ref == 'latest' }}
+          latest_ui: ${{ github.base_ref == 'latest' || github.ref_name == 'latest' }}
           rebuilt_base_images: ${{ steps.build_base_images.outputs.rebuilt_images }}
       
       - name: Set app version

--- a/images/pulp-minimal/stable/Containerfile.core
+++ b/images/pulp-minimal/stable/Containerfile.core
@@ -14,6 +14,7 @@ ARG PULP_OSTREE_VERSION=""
 ARG PULP_NPM_VERSION=""
 ARG PULP_HUGGING_FACE_VERSION=""
 
+ENV PULP_UI=${PULP_UI_URL:-false}
 COPY images/assets/requirements.extra.txt /requirements.extra.txt
 COPY images/assets/requirements.minimal.txt /requirements.minimal.txt
 
@@ -46,3 +47,9 @@ USER root:root
 
 RUN chmod 2775 /var/lib/pulp/{scripts,media,tmp,assets}
 RUN chown :root /var/lib/pulp/{scripts,media,tmp,assets}
+
+RUN \
+  if [ -n "$PULP_UI_URL" ]; then \
+    mkdir -p "${PULP_STATIC_ROOT}pulp_ui"; \
+    curl -Ls $PULP_UI_URL | tar -xzv -C "${PULP_STATIC_ROOT}pulp_ui"; \
+  fi


### PR DESCRIPTION
This PR resolves #712.

Additionally, it fixes the conditional (`latest_ui`) for including the UI on `:stable` tags.

Currently, it is only set to `true` if `github.base_ref == 'latest'`, however `base_ref` is only set on PRs:
> `github.base_ref`: The `base_ref` or target branch of the pull request in a workflow run. This property is only available when the event that triggers a workflow run is either `pull_request` or `pull_request_target`. ([source](https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#github-context))

We're now also allowing `github.ref_name == 'latest'`, so it also works for pushes to the `stable` branch.