### PR TITLE
Move plugin constraints generation to base_image action

### DIFF
--- a/.github/actions/base_images/action.yml
+++ b/.github/actions/base_images/action.yml
@@ -17,6 +17,19 @@ runs:
   steps:
     - uses: actions/checkout@v4
 
+    - name: Generate plugin version constraints
+      run: |
+        branch=${{ github.base_ref || github.ref_name }}
+        if [[ "${branch}" != "latest" ]]; then
+          echo "Generating supported-branch constraints for branch ${branch}"
+          python .ci/scripts/get_supported_specifiers.py >> images/assets/constraints.txt
+          echo "Plugin constraints:"
+          cat images/assets/constraints.txt
+        else
+          echo "Latest branch: no plugin constraints needed"
+        fi
+      shell: bash
+
     - name: Calculate base images hash
       run: |
         hash=${{ hashFiles('images/Containerfile.core.base', 'images/pulp_ci_centos/Containerfile', 'images/assets/**', 'images/s6_assets/**') }}

--- a/.github/actions/build_image/action.yml
+++ b/.github/actions/build_image/action.yml
@@ -57,19 +57,6 @@ runs:
         fi
       shell: bash
 
-    - name: Generate plugin version constraints
-      run: |
-        branch=${{ github.base_ref || github.ref_name }}
-        if [[ "${branch}" != "latest" ]]; then
-          echo "Generating supported-branch constraints for branch ${branch}"
-          python .ci/scripts/get_supported_specifiers.py >> images/assets/constraints.txt
-          echo "Plugin constraints:"
-          cat images/assets/constraints.txt
-        else
-          echo "Latest branch: no plugin constraints needed"
-        fi
-      shell: bash
-
     - name: Check if rebuild is needed
       id: rebuild_needed
       run: |


### PR DESCRIPTION
This way they are properly copied over into the base image and thus inherited by the pulp/pulp and pulp/pulp-minimal images.