### PR TITLE
Fix get_supported_specifiers returning constraints that were un-installable

### DIFF
--- a/.ci/scripts/check_up_to_date.py
+++ b/.ci/scripts/check_up_to_date.py
@@ -46,6 +46,9 @@ def check_update(branch, current_versions, plugin_specifiers=None, should_exit=T
                     continue
             core_version = cur_version
             new_versions["pulpcore"] = core_version
+    for core_spread, core_python in PYTHON_VERSIONS.items():
+        if core_version in core_spread.specifier:
+            break
 
     # Now check each plugin to see if they need updates
     for plugin in PACKAGES:
@@ -56,12 +59,8 @@ def check_update(branch, current_versions, plugin_specifiers=None, should_exit=T
         assert plugin_pypi_response.status_code == 200
         plugin_versions = sorted((parse(v) for v in plugin_pypi_response.json()["releases"].keys()), reverse=True)
         for version in plugin_versions:
-            if version <= plugin_version:
-                # Temp check for released images that are using non-supported plugin versions
-                if plugin in plugin_specifiers and plugin_version not in SpecifierSet(plugin_specifiers[plugin]):
-                    pass
-                else:
-                    break
+            if plugin in plugin_specifiers and version not in SpecifierSet(plugin_specifiers[plugin]):
+                continue
             version_pypi_response = requests.get(urljoin(INDEX, f"pypi/{plugin}/{version}/json"))
             assert version_pypi_response.status_code == 200
             version_python_response_json = version_pypi_response.json()
@@ -72,16 +71,12 @@ def check_update(branch, current_versions, plugin_specifiers=None, should_exit=T
             required_python_version = version_python_response_json["info"]["requires_python"]
             core_dep = next(filter(lambda dep: dep.startswith("pulpcore"), deps))
             if core_version in Requirement(core_dep).specifier:
-                for core_spread, core_python in PYTHON_VERSIONS.items():
-                    if core_version in core_spread.specifier:
-                        break
                 if required_python_version and not SpecifierSet(required_python_version).contains(core_python):
                     continue
-                if plugin in plugin_specifiers:
-                    if version not in SpecifierSet(plugin_specifiers[plugin]):
-                        continue
                 new_versions[plugin] = version
                 break
+        if plugin in new_versions and version == plugin_version:
+            del new_versions[plugin]
 
     if new_versions:
         print("Updates needed for:")
@@ -112,6 +107,8 @@ if __name__ == '__main__':
         with open(opts.plugin_specifiers) as f:
             lines = f.readlines()
             for line in lines:
+                if line.startswith("#"):
+                    continue
                 plugin, ge, specifier = line.rstrip("\n").partition(">=")
                 plugin_specifiers[plugin] = ge + specifier
     check_update(opts.branch, versions, plugin_specifiers=plugin_specifiers)

--- a/.ci/scripts/get_supported_specifiers.py
+++ b/.ci/scripts/get_supported_specifiers.py
@@ -5,10 +5,16 @@ and generate pip version specifiers that constrain installs to those branches.
 Can be imported as a module or run as CLI to output pip constraints format.
 """
 
+import argparse
 import requests
 from yaml import safe_load
+from packaging.requirements import Requirement
+from packaging.specifiers import SpecifierSet
+from packaging.version import parse
+from urllib.parse import urljoin
 
 GITHUB_RAW = "https://raw.githubusercontent.com/pulp/{repo}/main/template_config.yml"
+INDEX = "https://pypi.org"
 
 SKIP = {"pulp-file", "pulp-certguard", "pulpcore"}
 SKIP_PREFIX = "pulp-glue"
@@ -25,6 +31,11 @@ PACKAGES = [
     "pulp-python",
     "pulp-rpm",
 ]
+
+PYTHON_VERSIONS = {
+    Requirement("pulpcore>=3.22,<3.85"): "3.9",
+    Requirement("pulpcore>=3.85"): "3.11"
+}
 
 
 def pip_to_repo(pip_name):
@@ -72,8 +83,50 @@ def build_specifier(branches):
     return ",".join(parts)
 
 
-def get_specifiers(plugin_names=None):
+def check_installable(pulpcore_version, plugin, specifier):
+    """Check if the plugin and its constraints are installable with the given pulpcore version."""
+    for core_spread, core_python in PYTHON_VERSIONS.items():
+        if pulpcore_version in core_spread.specifier:
+            break
+    plugin_pypi_response = requests.get(urljoin(INDEX, f"pypi/{plugin}/json"))
+    assert plugin_pypi_response.status_code == 200
+    plugin_versions = sorted((parse(v) for v in plugin_pypi_response.json()["releases"].keys()), reverse=True)
+    for version in plugin_versions:
+        if version not in SpecifierSet(specifier):
+            continue
+        version_pypi_response = requests.get(urljoin(INDEX, f"pypi/{plugin}/{version}/json"))
+        assert version_pypi_response.status_code == 200
+        version_python_response_json = version_pypi_response.json()
+        deps = version_python_response_json["info"]["requires_dist"]
+        if deps is None:
+            continue
+        required_python_version = version_python_response_json["info"]["requires_python"]
+        core_dep = next(filter(lambda dep: dep.startswith("pulpcore"), deps))
+        if pulpcore_version in Requirement(core_dep).specifier:
+            if required_python_version and not SpecifierSet(required_python_version).contains(core_python):
+                continue
+            return True
+    return False
+
+
+def get_latest_plugin_z_version(plugin, branch):
+    """Get the latest z version of the plugin for the given branch."""
+    pypi_response = requests.get(urljoin(INDEX, f"pypi/{plugin}/json"))
+    assert pypi_response.status_code == 200
+    plugin_versions = sorted((parse(v) for v in pypi_response.json()["releases"].keys()), reverse=True)
+    target_version = parse(branch)
+    for version in plugin_versions:
+        if version.major == target_version.major and version.minor == target_version.minor:
+            return version
+    return None
+
+
+def get_specifiers(pulpcore_version=None, plugin_names=None):
     """Return dict of {pip_name: specifier_string} for plugins with known support."""
+    if pulpcore_version is None:
+        pulpcore_version = get_supported_branches("pulpcore")[-1]
+    if pulpcore_version.count(".") == 1:
+        pulpcore_version = get_latest_plugin_z_version("pulpcore", pulpcore_version)
     if plugin_names is None:
         plugin_names = PACKAGES
     result = {}
@@ -84,12 +137,16 @@ def get_specifiers(plugin_names=None):
         branches = get_supported_branches(repo)
         if branches:
             spec = build_specifier(branches)
-            if spec:
+            if spec and check_installable(pulpcore_version, pip_name, spec):
                 result[pip_name] = spec
     return result
 
 
 if __name__ == "__main__":
-    specifiers = get_specifiers()
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--pulpcore-version", required=False)
+    parser.add_argument("--plugin-names", required=False)
+    opts = parser.parse_args()
+    specifiers = get_specifiers(opts.pulpcore_version, opts.plugin_names)
     for name, spec in sorted(specifiers.items()):
         print(f"{name}{spec}")

--- a/.github/actions/base_images/action.yml
+++ b/.github/actions/base_images/action.yml
@@ -22,7 +22,7 @@ runs:
         branch=${{ github.base_ref || github.ref_name }}
         if [[ "${branch}" != "latest" ]]; then
           echo "Generating supported-branch constraints for branch ${branch}"
-          python .ci/scripts/get_supported_specifiers.py >> images/assets/constraints.txt
+          python .ci/scripts/get_supported_specifiers.py --pulpcore-version ${branch} >> images/assets/constraints.txt
           echo "Plugin constraints:"
           cat images/assets/constraints.txt
         else


### PR DESCRIPTION
On some older branches there are no supported branches that can be resolved for that pulpcore version. Skip adding the constraint if so.