### PR TITLE
Rework pulp-web nginx handling to be better align with pulp/pulp image features

### DIFF
--- a/.github/actions/build_image/action.yml
+++ b/.github/actions/build_image/action.yml
@@ -88,7 +88,7 @@ runs:
         if [[ "${{ inputs.image_name }}" == "pulp-minimal" ]]; then
           base_image=$(echo ${{ inputs.image_name }} | cut -d '-' -f1)
           podman build --format docker --pull=false --file images/${{ inputs.image_name }}/${{ inputs.image_variant }}/Containerfile.core --tag pulp/${{ inputs.image_name }}:ci --build-arg FROM_TAG=ci .
-          podman build --format docker --pull=false --file images/${{ inputs.image_name }}/${{ inputs.image_variant }}/Containerfile.webserver --tag pulp/${base_image}-web:ci --build-arg FROM_TAG=ci .
+          podman build --format docker --pull=false --file images/${{ inputs.image_name }}/${{ inputs.image_variant }}/Containerfile.webserver --tag pulp/${base_image}-web:ci --build-arg FROM_TAG=ci ${{ env.BUILD_UI_ARG }} .
         else
           podman build --format docker --pull=false --file images/${{ inputs.image_name }}/${{ inputs.image_variant }}/Containerfile --tag pulp/${{ inputs.image_name }}:ci --build-arg FROM_TAG=ci ${{ env.BUILD_UI_ARG }} .
         fi

--- a/CHANGES/806.bugfix
+++ b/CHANGES/806.bugfix
@@ -1,0 +1,1 @@
+Reworked pulp-web nginx configuration to support HTTPS, domain-enabled routes, configurable API root/content path, and the Pulp UI. The image is now self-contained and no longer requires external nginx config mounts.

--- a/images/compose/compose.folders.yml
+++ b/images/compose/compose.folders.yml
@@ -70,7 +70,6 @@ services:
 
   pulp_web:
     image: "pulp/pulp-web:latest"
-    command: ['/usr/bin/nginx.sh']
     depends_on:
       pulp_api:
         condition: service_healthy
@@ -79,10 +78,6 @@ services:
     ports:
       - "8080:8080"
     hostname: pulp
-    user: root
-    volumes:
-      - "./assets/bin/nginx.sh:/usr/bin/nginx.sh:Z"
-      - "./assets/nginx/nginx.conf.template:/etc/nginx/nginx.conf.template:Z"
     restart: always
 
   pulp_api:

--- a/images/compose/compose.yml
+++ b/images/compose/compose.yml
@@ -70,7 +70,6 @@ services:
 
   pulp_web:
     image: "pulp/pulp-web:latest"
-    command: ['/usr/bin/nginx.sh']
     depends_on:
       pulp_api:
         condition: service_healthy
@@ -79,10 +78,6 @@ services:
     ports:
       - "8080:8080"
     hostname: pulp
-    user: root
-    volumes:
-      - "./assets/bin/nginx.sh:/usr/bin/nginx.sh:Z"
-      - "./assets/nginx/nginx.conf.template:/etc/nginx/nginx.conf.template:Z"
     restart: always
 
   pulp_api:

--- a/images/pulp-minimal/nightly/Containerfile.webserver
+++ b/images/pulp-minimal/nightly/Containerfile.webserver
@@ -2,18 +2,46 @@ ARG FROM_TAG="nightly"
 FROM pulp/pulp-minimal:${FROM_TAG} as builder
 
 RUN mkdir -p /etc/nginx/pulp \
-             /www/data \
   && ln $(pip show pulp_ansible | sed -n -e 's/Location: //p')/pulp_ansible/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_ansible.conf \
   && ln $(pip show pulp_container | sed -n -e 's/Location: //p')/pulp_container/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_container.conf \
   && ln $(pip show pulp_python | sed -n -e 's/Location: //p')/pulp_python/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_python.conf
 
+ARG PULP_UI_URL=""
+RUN mkdir -p /var/lib/operator/static/pulp_ui && \
+  if [ -n "$PULP_UI_URL" ]; then \
+    curl -Ls "$PULP_UI_URL" | tar -xzv -C /var/lib/operator/static/pulp_ui; \
+  fi
+
 
 FROM docker.io/nginx:latest
 
-RUN mkdir -p /etc/nginx/pulp
-COPY --from=builder /etc/nginx/pulp/*.conf /etc/nginx/pulp
+ARG PULP_UI_URL=""
 
-RUN chmod 775 /var/cache/nginx /var/run
+RUN mkdir -p /etc/nginx/pulp \
+             /etc/nginx/pulp-web/templates \
+             /etc/nginx/pulp-web/server.d \
+             /etc/nginx/pulp-web/location.d \
+             /etc/nginx/pulp-web/http.d \
+             /var/lib/operator/static/pulp_ui
 
-# Run script uses standard ways to run the application
-CMD nginx -g "daemon off;"
+COPY --from=builder /etc/nginx/pulp/*.conf /etc/nginx/pulp/
+COPY --from=builder /var/lib/operator/static/pulp_ui/ /var/lib/operator/static/pulp_ui/
+
+COPY images/pulp-web/templates/ /etc/nginx/pulp-web/templates/
+COPY images/pulp-web/entrypoint.sh /entrypoint.sh
+
+RUN chmod +x /entrypoint.sh && \
+    chmod -R 775 /etc/nginx/pulp /etc/nginx/pulp-web /var/cache/nginx /var/run
+
+ENV PULP_UI=${PULP_UI_URL:+true} \
+    PULP_HTTPS=false \
+    PULP_DOMAIN_ENABLED=false \
+    PULP_API_ROOT=/pulp/ \
+    PULP_CONTENT_PATH=/pulp/content/ \
+    PULP_API_HOST=pulp_api \
+    PULP_CONTENT_HOST=pulp_content \
+    PULP_STATIC_ROOT=/var/lib/operator/static/
+
+EXPOSE 8080 8443
+
+CMD ["/entrypoint.sh"]

--- a/images/pulp-minimal/stable/Containerfile.core
+++ b/images/pulp-minimal/stable/Containerfile.core
@@ -14,7 +14,6 @@ ARG PULP_OSTREE_VERSION=""
 ARG PULP_NPM_VERSION=""
 ARG PULP_HUGGING_FACE_VERSION=""
 
-ENV PULP_UI=${PULP_UI_URL:-false}
 COPY images/assets/requirements.extra.txt /requirements.extra.txt
 COPY images/assets/requirements.minimal.txt /requirements.minimal.txt
 
@@ -47,9 +46,3 @@ USER root:root
 
 RUN chmod 2775 /var/lib/pulp/{scripts,media,tmp,assets}
 RUN chown :root /var/lib/pulp/{scripts,media,tmp,assets}
-
-RUN \
-  if [ -n "$PULP_UI_URL" ]; then \
-    mkdir -p "${PULP_STATIC_ROOT}pulp_ui"; \
-    curl -Ls $PULP_UI_URL | tar -xzv -C "${PULP_STATIC_ROOT}pulp_ui"; \
-  fi

--- a/images/pulp-minimal/stable/Containerfile.webserver
+++ b/images/pulp-minimal/stable/Containerfile.webserver
@@ -2,18 +2,46 @@ ARG FROM_TAG="stable"
 FROM pulp/pulp-minimal:${FROM_TAG} as builder
 
 RUN mkdir -p /etc/nginx/pulp \
-             /www/data \
   && ln $(pip show pulp_ansible | sed -n -e 's/Location: //p')/pulp_ansible/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_ansible.conf \
   && ln $(pip show pulp_container | sed -n -e 's/Location: //p')/pulp_container/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_container.conf \
   && ln $(pip show pulp_python | sed -n -e 's/Location: //p')/pulp_python/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_python.conf
 
+ARG PULP_UI_URL=""
+RUN mkdir -p /var/lib/operator/static/pulp_ui && \
+  if [ -n "$PULP_UI_URL" ]; then \
+    curl -Ls "$PULP_UI_URL" | tar -xzv -C /var/lib/operator/static/pulp_ui; \
+  fi
+
 
 FROM docker.io/nginx:latest
 
-RUN mkdir -p /etc/nginx/pulp
-COPY --from=builder /etc/nginx/pulp/*.conf /etc/nginx/pulp
+ARG PULP_UI_URL=""
 
-RUN chmod 775 /var/cache/nginx /var/run
+RUN mkdir -p /etc/nginx/pulp \
+             /etc/nginx/pulp-web/templates \
+             /etc/nginx/pulp-web/server.d \
+             /etc/nginx/pulp-web/location.d \
+             /etc/nginx/pulp-web/http.d \
+             /var/lib/operator/static/pulp_ui
 
-# Run script uses standard ways to run the application
-CMD nginx -g "daemon off;"
+COPY --from=builder /etc/nginx/pulp/*.conf /etc/nginx/pulp/
+COPY --from=builder /var/lib/operator/static/pulp_ui/ /var/lib/operator/static/pulp_ui/
+
+COPY images/pulp-web/templates/ /etc/nginx/pulp-web/templates/
+COPY images/pulp-web/entrypoint.sh /entrypoint.sh
+
+RUN chmod +x /entrypoint.sh && \
+    chmod -R 775 /etc/nginx/pulp /etc/nginx/pulp-web /var/cache/nginx /var/run
+
+ENV PULP_UI=${PULP_UI_URL:+true} \
+    PULP_HTTPS=false \
+    PULP_DOMAIN_ENABLED=false \
+    PULP_API_ROOT=/pulp/ \
+    PULP_CONTENT_PATH=/pulp/content/ \
+    PULP_API_HOST=pulp_api \
+    PULP_CONTENT_HOST=pulp_content \
+    PULP_STATIC_ROOT=/var/lib/operator/static/
+
+EXPOSE 8080 8443
+
+CMD ["/entrypoint.sh"]

--- a/images/pulp-web/entrypoint.sh
+++ b/images/pulp-web/entrypoint.sh
@@ -1,0 +1,93 @@
+#!/bin/sh
+set -e
+
+# When the pulp-operator (or another orchestrator) mounts its own nginx.conf
+# via a read-only ConfigMap, skip all config generation and just start nginx.
+# The operator's config uses static upstream blocks that match Kubernetes
+# service names, so plugin snippets work without rewriting.
+if [ -f /etc/nginx/nginx.conf ] && ! touch /etc/nginx/nginx.conf 2>/dev/null; then
+  echo "Detected externally-managed nginx.conf (read-only), skipping config generation"
+  exec nginx -g "daemon off;"
+fi
+
+PULP_API_HOST="${PULP_API_HOST:-pulp_api}"
+PULP_CONTENT_HOST="${PULP_CONTENT_HOST:-pulp_content}"
+PULP_CONTENT_PATH="${PULP_CONTENT_PATH:-/pulp/content/}"
+PULP_API_ROOT="${PULP_API_ROOT:-/pulp/}"
+PULP_HTTPS="${PULP_HTTPS:-false}"
+PULP_UI="${PULP_UI:-false}"
+PULP_DOMAIN_ENABLED="${PULP_DOMAIN_ENABLED:-false}"
+PULP_STATIC_ROOT="${PULP_STATIC_ROOT:-/var/lib/operator/static/}"
+
+export PULP_API_HOST PULP_CONTENT_HOST PULP_CONTENT_PATH PULP_API_ROOT
+
+# Resolve nameserver for DNS-based service discovery
+# https://serverfault.com/a/821625/189494
+if [ "${container}" = "podman" ]; then
+  NAMESERVER=$(awk '/^nameserver/{print $2; exit}' /etc/resolv.conf)
+else
+  NAMESERVER=$(awk '/^nameserver/{print $2}' /etc/resolv.conf | tr '\n' ' ')
+fi
+export NAMESERVER
+echo "Nameserver is: ${NAMESERVER}"
+
+TEMPLATES=/etc/nginx/pulp-web/templates
+SERVER_D=/etc/nginx/pulp-web/server.d
+LOCATION_D=/etc/nginx/pulp-web/location.d
+HTTP_D=/etc/nginx/pulp-web/http.d
+
+# Clean any previously-generated snippets
+rm -f "${SERVER_D}"/*.conf "${LOCATION_D}"/*.conf "${HTTP_D}"/*.conf
+
+# --- Listen / SSL ---
+if [ "${PULP_HTTPS}" = "true" ]; then
+  echo "Enabling HTTPS"
+  cp "${TEMPLATES}/listen-https.conf" "${SERVER_D}/listen.conf"
+  cp "${TEMPLATES}/http-redirect.conf" "${HTTP_D}/redirect.conf"
+  cp "${TEMPLATES}/acme.conf"          "${LOCATION_D}/acme.conf"
+else
+  cp "${TEMPLATES}/listen-http.conf" "${SERVER_D}/listen.conf"
+fi
+
+# --- Domain-enabled routes ---
+if [ "${PULP_DOMAIN_ENABLED}" = "true" ]; then
+  echo "Enabling domain routes"
+  envsubst '${PULP_API_ROOT}' \
+    < "${TEMPLATES}/domains.conf.template" \
+    > "${LOCATION_D}/domains.conf"
+fi
+
+# --- UI ---
+if [ "${PULP_UI}" != "false" ] && [ -n "${PULP_UI}" ]; then
+  PULP_UI_STATIC="${PULP_STATIC_ROOT}pulp_ui/"
+  # Strip trailing "static/pulp_ui/" to get the root for nginx's root directive
+  PULP_UI_ROOT=$(echo "${PULP_UI_STATIC}" | sed 's|static/pulp_ui/$||')
+  export PULP_UI_STATIC PULP_UI_ROOT
+  if [ -d "${PULP_UI_STATIC}" ] && [ "$(ls -A "${PULP_UI_STATIC}" 2>/dev/null)" ]; then
+    echo "Enabling UI (serving from ${PULP_UI_STATIC})"
+    envsubst '${PULP_UI_STATIC} ${PULP_UI_ROOT}' \
+      < "${TEMPLATES}/ui.conf.template" \
+      > "${LOCATION_D}/ui.conf"
+  else
+    echo "Warning: PULP_UI is set but no files found at ${PULP_UI_STATIC}, skipping UI"
+  fi
+fi
+
+# --- Main config ---
+echo "Generating nginx.conf"
+envsubst '${NAMESERVER} ${PULP_API_HOST} ${PULP_CONTENT_HOST} ${PULP_CONTENT_PATH} ${PULP_API_ROOT}' \
+  < "${TEMPLATES}/nginx.conf.template" \
+  > /etc/nginx/nginx.conf
+
+# --- Plugin snippets ---
+# Rewrite upstream references so nginx uses the resolver-backed variables
+# instead of static upstream names.
+for file in /etc/nginx/pulp/*.conf; do
+  [ -f "${file}" ] || continue
+  echo "Rewriting upstream references in ${file}"
+  sed -i 's|proxy_pass http://pulp-api|proxy_pass http://$pulp_api:24817|g' "${file}"
+  sed -i 's|proxy_pass http://pulp-content|proxy_pass http://$pulp_content:24816|g' "${file}"
+done
+
+echo "Starting nginx"
+exec nginx -g "daemon off;"

--- a/images/pulp-web/templates/acme.conf
+++ b/images/pulp-web/templates/acme.conf
@@ -1,0 +1,3 @@
+location /.well-known/ {
+    try_files $uri $uri/ =404;
+}

--- a/images/pulp-web/templates/domains.conf.template
+++ b/images/pulp-web/templates/domains.conf.template
@@ -1,0 +1,8 @@
+location ~ ${PULP_API_ROOT}.+/api/v3/ {
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header Host $http_host;
+    proxy_redirect off;
+    proxy_pass http://$pulp_api:24817;
+    client_max_body_size 0;
+}

--- a/images/pulp-web/templates/http-redirect.conf
+++ b/images/pulp-web/templates/http-redirect.conf
@@ -1,0 +1,6 @@
+server {
+    listen 8080 default_server;
+    listen [::]:8080 default_server;
+    server_name _;
+    return 301 https://$host$request_uri;
+}

--- a/images/pulp-web/templates/listen-http.conf
+++ b/images/pulp-web/templates/listen-http.conf
@@ -1,0 +1,2 @@
+listen 8080 default_server deferred;
+listen [::]:8080 default_server deferred;

--- a/images/pulp-web/templates/listen-https.conf
+++ b/images/pulp-web/templates/listen-https.conf
@@ -1,0 +1,16 @@
+listen 8443 default_server deferred ssl;
+listen [::]:8443 default_server deferred ssl;
+
+ssl_certificate /etc/pulp/certs/pulp_webserver.crt;
+ssl_certificate_key /etc/pulp/certs/pulp_webserver.key;
+ssl_session_cache shared:SSL:50m;
+ssl_session_timeout 1d;
+ssl_session_tickets off;
+
+# intermediate configuration
+ssl_protocols TLSv1.2;
+ssl_ciphers 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256';
+ssl_prefer_server_ciphers on;
+
+# HSTS (15768000 seconds = 6 months)
+add_header Strict-Transport-Security max-age=15768000;

--- a/images/pulp-web/templates/nginx.conf.template
+++ b/images/pulp-web/templates/nginx.conf.template
@@ -1,0 +1,74 @@
+error_log /dev/stdout info;
+worker_processes 1;
+events {
+    worker_connections 1024;
+    accept_mutex off;
+}
+
+http {
+    access_log /dev/stdout;
+    include mime.types;
+    default_type application/octet-stream;
+    sendfile on;
+
+    # If left at the default of 1024, nginx emits a warning about being unable
+    # to build optimal hash types.
+    types_hash_max_size 4096;
+
+    server {
+        # Re-resolve DNS names every 10s for scaled services.
+        # https://www.nginx.com/blog/dns-service-discovery-nginx-plus#domain-name-variable
+        resolver ${NAMESERVER} valid=10s;
+        set $pulp_api ${PULP_API_HOST};
+        set $pulp_content ${PULP_CONTENT_HOST};
+
+        include /etc/nginx/pulp-web/server.d/*.conf;
+
+        server_name $hostname;
+
+        # The default client_max_body_size is 1m. Clients uploading
+        # files larger than this will need to chunk said files.
+        client_max_body_size 10m;
+
+        # Gunicorn docs suggest this value.
+        keepalive_timeout 5;
+
+        location ${PULP_CONTENT_PATH} {
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Host $http_host;
+            proxy_redirect off;
+            proxy_pass http://$pulp_content:24816;
+        }
+
+        location ${PULP_API_ROOT}api/v3/ {
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Host $http_host;
+            proxy_redirect off;
+            proxy_pass http://$pulp_api:24817;
+            client_max_body_size 0;
+        }
+
+        location /auth/login/ {
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Host $http_host;
+            proxy_redirect off;
+            proxy_pass http://$pulp_api:24817;
+        }
+
+        include /etc/nginx/pulp/*.conf;
+        include /etc/nginx/pulp-web/location.d/*.conf;
+
+        location / {
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Host $http_host;
+            proxy_redirect off;
+            proxy_pass http://$pulp_api:24817;
+        }
+    }
+
+    include /etc/nginx/pulp-web/http.d/*.conf;
+}

--- a/images/pulp-web/templates/ui.conf.template
+++ b/images/pulp-web/templates/ui.conf.template
@@ -1,0 +1,11 @@
+location /static/pulp_ui/ {
+    root ${PULP_UI_ROOT};
+    try_files $uri /static/pulp_ui/index.html;
+}
+location /ui/ {
+    alias ${PULP_UI_STATIC};
+    try_files $uri /static/pulp_ui/index.html;
+}
+location /pulp-ui-config.json {
+    root ${PULP_UI_STATIC};
+}


### PR DESCRIPTION
pulp-web can now properly handle changing API_ROOT & CONTENT_PATH_PREFIX from defaults. pulp-web also now properly supports HTTPS and the UI.

Generated by: Claude-Opus-4.6
fixes: #806