### PR TITLE
Create Valkey runtime directories in CS10 CI image

### DIFF
--- a/images/pulp_ci_centos/Containerfile.cs10
+++ b/images/pulp_ci_centos/Containerfile.cs10
@@ -29,10 +29,13 @@ RUN dnf -y install "https://download.postgresql.org/pub/repos/yum/reporpms/EL-10
     dnf clean all
 
 # Valkey compatibility: s6 service scripts expect redis-server, redis user, and /etc/redis/redis.conf
+# Also create runtime directories that tmpfiles.d would normally handle via systemd
 RUN ln -s /usr/bin/valkey-server /usr/bin/redis-server && \
     ln -s /etc/valkey /etc/redis && \
     ln -s /etc/valkey/valkey.conf /etc/valkey/redis.conf && \
-    useradd -o -u $(id -u valkey) -g $(id -g valkey) -M -N redis || true
+    useradd -o -u $(id -u valkey) -g $(id -g valkey) -M -N redis || true && \
+    install -d -m 0755 -o valkey -g valkey /run/valkey && \
+    install -d -m 0750 -o valkey -g valkey /var/log/valkey
 
 RUN alternatives --install /usr/bin/postgres postgres /usr/pgsql-16/bin/postgres 160 \
       --follower /usr/bin/pg_dump pg_dump /usr/pgsql-16/bin/pg_dump \

--- a/images/s6_assets/pulp_tests.sh
+++ b/images/s6_assets/pulp_tests.sh
@@ -13,6 +13,8 @@ grep "127.0.0.1   pulp" /etc/hosts || echo "127.0.0.1   pulp" | sudo tee -a /etc
 
 echo "Installing Pulp-CLI"
 pip install pulp-cli
+echo "Installing uv"
+pip install uv
 
 # Retreive installed pulp-cli version
 PULP_CLI_VERSION=$(python3 -c \
@@ -30,7 +32,12 @@ else
   cd pulp-cli
 fi
 
-pip install -r test_requirements.txt || pip install --no-build-isolation -r test_requirements.txt
+# Newer pulp-cli versions (>= 0.39) removed test_requirements.txt and use uv
+# dependency groups instead; `make paralleltest` below calls `uv run` which
+# handles installing test deps automatically.
+if [ -f test_requirements.txt ]; then
+  pip install -r test_requirements.txt || pip install --no-build-isolation -r test_requirements.txt
+fi
 
 if [ -e tests/cli.toml ]; then
   mv tests/cli.toml "tests/cli.toml.bak.$(date -R)"


### PR DESCRIPTION
Valkey's default config uses /run/valkey/ for its pidfile and Unix socket, and /var/log/valkey/ for its logfile. These directories are normally created by systemd-tmpfiles which doesn't run in containers. On CS9, Redis used /var/run/redis_6379.pid (no subdirectory) and no Unix socket, so it worked without runtime directories.

Without these directories, Valkey fails to start with:
  Failed to write PID file: No such file or directory
  Failed opening Unix socket: bind: No such file or directory

This caused all Azure CI tests to fail since the Azure scenario uses worker_type=redis.

Assisted-By: Claude Opus 4.6