### PR TITLE
Fix pulp-cli test deps install for releases without test_requirements.txt

### DIFF
--- a/images/s6_assets/pulp_tests.sh
+++ b/images/s6_assets/pulp_tests.sh
@@ -30,7 +30,12 @@ else
   cd pulp-cli
 fi
 
-pip install -r test_requirements.txt || pip install --no-build-isolation -r test_requirements.txt
+if [ -f test_requirements.txt ]; then
+  pip install -r test_requirements.txt || pip install --no-build-isolation -r test_requirements.txt
+else
+  # pulp-cli >= 0.40 moved test deps into pyproject.toml dependency groups
+  pip install --group test
+fi
 
 if [ -e tests/cli.toml ]; then
   mv tests/cli.toml "tests/cli.toml.bak.$(date -R)"


### PR DESCRIPTION
pulp-cli 0.40+ dropped test_requirements.txt in favor of pyproject.toml dependency groups; fall back to pip install --group test when the file is missing so nightly image tests keep working.