### PR TITLE
[3.49] Upgrade base images to Python 3.11 and PostgreSQL 16

### DIFF
--- a/.ci/scripts/check_up_to_date.py
+++ b/.ci/scripts/check_up_to_date.py
@@ -21,8 +21,7 @@ PACKAGES = [
 INDEX = "https://pypi.org"
 
 PYTHON_VERSIONS = {
-    Requirement("pulpcore>=3.22,<3.85"): "3.9",
-    Requirement("pulpcore>=3.85"): "3.11"
+    Requirement("pulpcore>=3.22"): "3.11",
 }
 
 def check_update(branch, current_versions, plugin_specifiers=None, should_exit=True):

--- a/.ci/scripts/get_supported_specifiers.py
+++ b/.ci/scripts/get_supported_specifiers.py
@@ -33,8 +33,7 @@ PACKAGES = [
 ]
 
 PYTHON_VERSIONS = {
-    Requirement("pulpcore>=3.22,<3.85"): "3.9",
-    Requirement("pulpcore>=3.85"): "3.11"
+    Requirement("pulpcore>=3.22"): "3.11",
 }
 
 

--- a/.github/actions/test_image/action.yml
+++ b/.github/actions/test_image/action.yml
@@ -23,7 +23,7 @@ runs:
       if: inputs.image_name == 'pulp'
       run: |
         # 3.49 has postgres 13 rather than 16
-        images/s6_assets/test.sh "pulp/${{ inputs.image_name }}:ci" http "quay.io/pulp/pulp:3.49"
+        images/s6_assets/test.sh "pulp/${{ inputs.image_name }}:ci" http "quay.io/pulp/pulp:3.49" "${{ inputs.app_branch }}"
         podman stop pulp
         podman rm pulp
       shell: bash

--- a/.github/actions/test_image/action.yml
+++ b/.github/actions/test_image/action.yml
@@ -22,8 +22,9 @@ runs:
     - name: Test image with upgrade in s6 mode (pulp)
       if: inputs.image_name == 'pulp'
       run: |
-        # 3.49 has postgres 13 rather than 16
-        images/s6_assets/test.sh "pulp/${{ inputs.image_name }}:ci" http "quay.io/pulp/pulp:3.49" "${{ inputs.app_branch }}"
+        # Pin to 3.49.0 so the upgrade source always has PostgreSQL 13,
+        # even after the floating 3.49 tag moves to PostgreSQL 16.
+        images/s6_assets/test.sh "pulp/${{ inputs.image_name }}:ci" http "quay.io/pulp/pulp:3.49.0" "${{ inputs.app_branch }}"
         podman stop pulp
         podman rm pulp
       shell: bash

--- a/.github/actions/test_image/action.yml
+++ b/.github/actions/test_image/action.yml
@@ -22,10 +22,10 @@ runs:
     - name: Test image with upgrade in s6 mode (pulp)
       if: inputs.image_name == 'pulp'
       run: |
-        # Pin to 3.49.62 so the upgrade source always has PostgreSQL 13,
-        # even after the floating 3.49 tag moves to PostgreSQL 16.
+        # Pin to 3.49.61 so the upgrade source always has PostgreSQL 13,
+        # even after the floating 3.49 / latest 3.49.z tags move to PostgreSQL 16.
         # Avoid older 3.49.z tags (e.g. 3.49.0) that fail to start on arm64.
-        images/s6_assets/test.sh "pulp/${{ inputs.image_name }}:ci" http "quay.io/pulp/pulp:3.49.62" "${{ inputs.app_branch }}"
+        images/s6_assets/test.sh "pulp/${{ inputs.image_name }}:ci" http "quay.io/pulp/pulp:3.49.61" "${{ inputs.app_branch }}"
         podman stop pulp
         podman rm pulp
       shell: bash

--- a/.github/actions/test_image/action.yml
+++ b/.github/actions/test_image/action.yml
@@ -22,7 +22,10 @@ runs:
     - name: Test image with upgrade in s6 mode (pulp)
       if: inputs.image_name == 'pulp'
       run: |
-        images/s6_assets/test.sh "pulp/${{ inputs.image_name }}:ci" http
+        # 3.49 has postgres 13 rather than 16
+        images/s6_assets/test.sh "pulp/${{ inputs.image_name }}:ci" http "quay.io/pulp/pulp:3.49"
+        podman stop pulp
+        podman rm pulp
       shell: bash
 
     - name: Test Compose up

--- a/.github/actions/test_image/action.yml
+++ b/.github/actions/test_image/action.yml
@@ -22,9 +22,10 @@ runs:
     - name: Test image with upgrade in s6 mode (pulp)
       if: inputs.image_name == 'pulp'
       run: |
-        # Pin to 3.49.0 so the upgrade source always has PostgreSQL 13,
+        # Pin to 3.49.62 so the upgrade source always has PostgreSQL 13,
         # even after the floating 3.49 tag moves to PostgreSQL 16.
-        images/s6_assets/test.sh "pulp/${{ inputs.image_name }}:ci" http "quay.io/pulp/pulp:3.49.0" "${{ inputs.app_branch }}"
+        # Avoid older 3.49.z tags (e.g. 3.49.0) that fail to start on arm64.
+        images/s6_assets/test.sh "pulp/${{ inputs.image_name }}:ci" http "quay.io/pulp/pulp:3.49.62" "${{ inputs.app_branch }}"
         podman stop pulp
         podman rm pulp
       shell: bash

--- a/CHANGES/826.bugfix
+++ b/CHANGES/826.bugfix
@@ -1,0 +1,1 @@
+Skip installing pulp-deb and pulp-maven on 3.49 images where no domain-compatible versions exist.

--- a/CHANGES/826.bugfix
+++ b/CHANGES/826.bugfix
@@ -1,1 +1,0 @@
-Skip installing pulp-deb and pulp-maven on 3.49 images where no supported versions exist, only run domain-enabled s6 tests on the latest branch, and support pulp-cli releases without test_requirements.txt.

--- a/CHANGES/826.bugfix
+++ b/CHANGES/826.bugfix
@@ -1,1 +1,1 @@
-Skip installing pulp-deb and pulp-maven on 3.49 images where no domain-compatible versions exist.
+Skip installing pulp-deb and pulp-maven on 3.49 images where no supported versions exist, and only run domain-enabled s6 tests on the latest branch.

--- a/CHANGES/826.bugfix
+++ b/CHANGES/826.bugfix
@@ -1,1 +1,1 @@
-Skip installing pulp-deb and pulp-maven on 3.49 images where no supported versions exist, and only run domain-enabled s6 tests on the latest branch.
+Skip installing pulp-deb and pulp-maven on 3.49 images where no supported versions exist, only run domain-enabled s6 tests on the latest branch, and support pulp-cli releases without test_requirements.txt.

--- a/images/Containerfile.core.base
+++ b/images/Containerfile.core.base
@@ -1,6 +1,4 @@
 FROM quay.io/centos/centos:stream9
-# https://ryandaniels.ca/blog/docker-dockerfile-arg-from-arg-trouble/
-ARG PYTHON_VERSION=3.9
 
 # https://superuser.com/questions/959380/how-do-i-install-generate-all-locales-on-fedora
 # This may not be necessary anymore because Fedora 30, unlike CentOS 7, has
@@ -36,32 +34,15 @@ RUN dnf -y module enable nginx:1.22
 
 # glibc-langpack-en is needed to provide the en_US.UTF-8 locale, which Pulp
 # seems to need.
-#
-# The last 5 lines (before clean) are needed until python3-createrepo_c gets an
-# RPM upgrade to 0.16.2. Until then, we install & build it from PyPI.
-#
-# TODO: Investigate differences between `dnf builddep createrepo_c` vs the list
-# of dependencies below. For example, drpm-devel.
-RUN dnf -y install python${PYTHON_VERSION} python3-cryptography python${PYTHON_VERSION}-devel && \
+# cairo/gobject are needed for PyGObject, which pulp_ostree requires
+RUN dnf -y install python3.11 python3.11-pip python3.11-devel && \
     dnf -y install openssl openssl-devel && \
     dnf -y install openldap-devel --exclude selinux* && \
     dnf -y install wget git && \
-    dnf -y install python3-psycopg2 && \
-    dnf -y install redhat-rpm-config gcc cargo libffi-devel && \
+    dnf -y install gcc libffi-devel && \
     dnf -y install glibc-langpack-en && \
-    dnf -y install python3-libmodulemd && \
-    dnf -y install python3-libcomps && \
-    dnf -y install libpq-devel && \
-    dnf -y install python3-setuptools && \
-    dnf -y install swig && \
     dnf -y install podman fuse-overlayfs buildah --exclude container-selinux && \
-    dnf -y install xz && \
-    dnf -y install libmodulemd-devel && \
-    dnf -y install libcomps-devel && \
-    dnf -y install zchunk-devel && \
-    dnf -y install ninja-build && \
-    dnf -y install cairo-devel cmake gobject-introspection-devel cairo-gobject-devel && \
-    dnf -y install libcurl-devel libxml2-devel sqlite-devel file-devel && \
+    dnf -y install cairo-devel gobject-introspection-devel cairo-gobject-devel && \
     dnf -y install ostree-libs ostree && \
     dnf -y install skopeo && \
     dnf -y install sudo && \
@@ -72,6 +53,11 @@ RUN dnf -y install python${PYTHON_VERSION} python3-cryptography python${PYTHON_V
     dnf -y install lsof && \
     getcap /usr/bin/newuidmap  | grep cap_setuid || dnf -y reinstall -y shadow-utils && \
     dnf clean all
+
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.11 20
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 20
+RUN update-alternatives --install /usr/bin/pip pip /usr/bin/pip3.11 20
+RUN update-alternatives --install /usr/bin/pip3 pip3 /usr/bin/pip3.11 20
 
 RUN groupadd -g 700 --system pulp
 RUN useradd -d /var/lib/pulp --system -u 700 -g pulp pulp

--- a/images/assets/readyz.py
+++ b/images/assets/readyz.py
@@ -53,7 +53,7 @@ gunicorn: master \[pulp-{content,api}\]
 OR
 ```
 # RPM installation
-/usr/bin/python3.9/usr/bin/gunicorn--bind[::]:2481{6,7}pulpcore.app.wsgi:application--namepulp-{api,content}--timeout90--workers2
+/usr/bin/python3.11/usr/bin/gunicorn--bind[::]:2481{6,7}pulpcore.app.wsgi:application--namepulp-{api,content}--timeout90--workers2
 ```
 """
 with open("/proc/1/cmdline", "r") as f:

--- a/images/compose/compose.folders.yml
+++ b/images/compose/compose.folders.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   postgres:
-    image: "docker.io/library/postgres:13"
+    image: "docker.io/library/postgres:16"
     ports:
       - "5432:5432"
     environment:

--- a/images/compose/compose.yml
+++ b/images/compose/compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   postgres:
-    image: "docker.io/library/postgres:13"
+    image: "docker.io/library/postgres:16"
     ports:
       - "5432:5432"
     environment:

--- a/images/galaxy-minimal/nightly/Containerfile.core
+++ b/images/galaxy-minimal/nightly/Containerfile.core
@@ -1,7 +1,7 @@
 ARG FROM_TAG="latest"
 FROM pulp/base:${FROM_TAG}
 
-RUN pip3 install git+https://github.com/ansible/galaxy_ng \
+RUN pip install git+https://github.com/ansible/galaxy_ng \
   -c /constraints.txt && \
   rm -rf /root/.cache/pip
 

--- a/images/galaxy-minimal/nightly/Containerfile.webserver
+++ b/images/galaxy-minimal/nightly/Containerfile.webserver
@@ -3,11 +3,11 @@ FROM pulp/galaxy-minimal:${FROM_TAG} as builder
 
 RUN mkdir -p /etc/nginx/pulp \
              /www/data
-RUN ln $(pip3 show pulp_ansible | sed -n -e 's/Location: //p')/pulp_ansible/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_ansible.conf
-RUN ln $(pip3 show pulp_container | sed -n -e 's/Location: //p')/pulp_container/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_container.conf
-RUN ln $(pip3 show galaxy_ng | sed -n -e 's/Location: //p')/galaxy_ng/app/webserver_snippets/nginx.conf /etc/nginx/pulp/galaxy_ng.conf
+RUN ln $(pip show pulp_ansible | sed -n -e 's/Location: //p')/pulp_ansible/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_ansible.conf
+RUN ln $(pip show pulp_container | sed -n -e 's/Location: //p')/pulp_container/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_container.conf
+RUN ln $(pip show galaxy_ng | sed -n -e 's/Location: //p')/galaxy_ng/app/webserver_snippets/nginx.conf /etc/nginx/pulp/galaxy_ng.conf
 
-RUN cp -fr /usr/local/lib/python3.9/site-packages/galaxy_ng/app/static/galaxy_ng/. /www/data
+RUN cp -fr /usr/local/lib/python3.11/site-packages/galaxy_ng/app/static/galaxy_ng/. /www/data
 
 
 FROM docker.io/centos/nginx-116-centos7:1.16

--- a/images/galaxy-minimal/stable/Containerfile.core
+++ b/images/galaxy-minimal/stable/Containerfile.core
@@ -4,7 +4,7 @@ FROM pulp/base:${FROM_TAG}
 ARG PULPCORE_VERSION=""
 ARG GALAXY_NG_VERSION=""
 
-RUN pip3 install --upgrade \
+RUN pip install --upgrade \
   galaxy-ng${GALAXY_NG_VERSION} \
   pulpcore${PULPCORE_VERSION} \
   -c /constraints.txt && \

--- a/images/galaxy-minimal/stable/Containerfile.webserver
+++ b/images/galaxy-minimal/stable/Containerfile.webserver
@@ -3,11 +3,11 @@ FROM pulp/galaxy-minimal:${FROM_TAG} as builder
 
 RUN mkdir -p /etc/nginx/pulp \
              /www/data
-RUN ln $(pip3 show pulp_ansible | sed -n -e 's/Location: //p')/pulp_ansible/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_ansible.conf
-RUN ln $(pip3 show pulp_container | sed -n -e 's/Location: //p')/pulp_container/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_container.conf
-RUN ln $(pip3 show galaxy_ng | sed -n -e 's/Location: //p')/galaxy_ng/app/webserver_snippets/nginx.conf /etc/nginx/pulp/galaxy_ng.conf
+RUN ln $(pip show pulp_ansible | sed -n -e 's/Location: //p')/pulp_ansible/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_ansible.conf
+RUN ln $(pip show pulp_container | sed -n -e 's/Location: //p')/pulp_container/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_container.conf
+RUN ln $(pip show galaxy_ng | sed -n -e 's/Location: //p')/galaxy_ng/app/webserver_snippets/nginx.conf /etc/nginx/pulp/galaxy_ng.conf
 
-RUN cp -fr /usr/local/lib/python3.9/site-packages/galaxy_ng/app/static/galaxy_ng/. /www/data
+RUN cp -fr /usr/local/lib/python3.11/site-packages/galaxy_ng/app/static/galaxy_ng/. /www/data
 
 
 FROM docker.io/centos/nginx-116-centos7:1.16

--- a/images/galaxy/nightly/Containerfile
+++ b/images/galaxy/nightly/Containerfile
@@ -3,7 +3,7 @@ FROM pulp/pulp-ci-centos9:${FROM_TAG}
 
 ARG GALAXY_NG_VERSION=""
 
-RUN pip3 install --upgrade \
+RUN pip install --upgrade \
   git+https://github.com/ansible/galaxy_ng.git@master \
   requests \
   -c /constraints.txt && \
@@ -14,9 +14,9 @@ RUN PULP_STATIC_ROOT=/var/lib/operator/static/ PULP_CONTENT_ORIGIN=localhost \
        /usr/local/bin/pulpcore-manager collectstatic --clear --noinput --link
 USER root:root
 
-RUN ln $(pip3 show pulp_ansible | sed -n -e 's/Location: //p')/pulp_ansible/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_ansible.conf
-RUN ln $(pip3 show pulp_container | sed -n -e 's/Location: //p')/pulp_container/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_container.conf
-RUN ln $(pip3 show galaxy_ng | sed -n -e 's/Location: //p')/galaxy_ng/app/webserver_snippets/nginx.conf /etc/nginx/pulp/galaxy_ng.conf
+RUN ln $(pip show pulp_ansible | sed -n -e 's/Location: //p')/pulp_ansible/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_ansible.conf
+RUN ln $(pip show pulp_container | sed -n -e 's/Location: //p')/pulp_container/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_container.conf
+RUN ln $(pip show galaxy_ng | sed -n -e 's/Location: //p')/galaxy_ng/app/webserver_snippets/nginx.conf /etc/nginx/pulp/galaxy_ng.conf
 
 # allow configuration via env variables
 ENV S6_KEEP_ENV=1

--- a/images/galaxy/stable/Containerfile
+++ b/images/galaxy/stable/Containerfile
@@ -4,7 +4,7 @@ FROM pulp/pulp-ci-centos9:${FROM_TAG}
 ARG PULPCORE_VERSION=""
 ARG GALAXY_NG_VERSION=""
 
-RUN pip3 install --upgrade \
+RUN pip install --upgrade \
   galaxy-ng${GALAXY_NG_VERSION} \
   pulpcore${PULPCORE_VERSION} \
   requests \
@@ -16,9 +16,9 @@ RUN PULP_STATIC_ROOT=/var/lib/operator/static/ PULP_CONTENT_ORIGIN=localhost \
        /usr/local/bin/pulpcore-manager collectstatic --clear --noinput --link
 USER root:root
 
-RUN ln $(pip3 show pulp_ansible | sed -n -e 's/Location: //p')/pulp_ansible/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_ansible.conf
-RUN ln $(pip3 show pulp_container | sed -n -e 's/Location: //p')/pulp_container/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_container.conf
-RUN ln $(pip3 show galaxy_ng | sed -n -e 's/Location: //p')/galaxy_ng/app/webserver_snippets/nginx.conf /etc/nginx/pulp/galaxy_ng.conf
+RUN ln $(pip show pulp_ansible | sed -n -e 's/Location: //p')/pulp_ansible/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_ansible.conf
+RUN ln $(pip show pulp_container | sed -n -e 's/Location: //p')/pulp_container/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_container.conf
+RUN ln $(pip show galaxy_ng | sed -n -e 's/Location: //p')/galaxy_ng/app/webserver_snippets/nginx.conf /etc/nginx/pulp/galaxy_ng.conf
 
 # allow configuration via env variables
 ENV S6_KEEP_ENV=1

--- a/images/pulp-minimal/nightly/Containerfile.core
+++ b/images/pulp-minimal/nightly/Containerfile.core
@@ -1,7 +1,7 @@
 ARG FROM_TAG="latest"
 FROM pulp/base:${FROM_TAG}
 
-RUN pip3 install git+https://github.com/pulp/pulpcore.git#egg=pulpcore \
+RUN pip install git+https://github.com/pulp/pulpcore.git#egg=pulpcore \
   git+https://github.com/pulp/pulp_ansible.git \
   git+https://github.com/pulp/pulp-certguard.git \
   git+https://github.com/pulp/pulp_container.git \

--- a/images/pulp-minimal/nightly/Containerfile.webserver
+++ b/images/pulp-minimal/nightly/Containerfile.webserver
@@ -3,9 +3,9 @@ FROM pulp/pulp-minimal:${FROM_TAG} as builder
 
 RUN mkdir -p /etc/nginx/pulp \
              /www/data
-RUN ln $(pip3 show pulp_ansible | sed -n -e 's/Location: //p')/pulp_ansible/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_ansible.conf
-RUN ln $(pip3 show pulp_container | sed -n -e 's/Location: //p')/pulp_container/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_container.conf
-RUN ln $(pip3 show pulp_python | sed -n -e 's/Location: //p')/pulp_python/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_python.conf
+RUN ln $(pip show pulp_ansible | sed -n -e 's/Location: //p')/pulp_ansible/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_ansible.conf
+RUN ln $(pip show pulp_container | sed -n -e 's/Location: //p')/pulp_container/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_container.conf
+RUN ln $(pip show pulp_python | sed -n -e 's/Location: //p')/pulp_python/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_python.conf
 
 
 

--- a/images/pulp-minimal/stable/Containerfile.core
+++ b/images/pulp-minimal/stable/Containerfile.core
@@ -12,7 +12,7 @@ ARG PULP_PYTHON_VERSION=""
 ARG PULP_RPM_VERSION=""
 ARG PULP_OSTREE_VERSION=""
 
-RUN pip3 install --upgrade \
+RUN pip install --upgrade \
   pulpcore${PULPCORE_VERSION} \
   pulp-ansible${PULP_ANSIBLE_VERSION} \
   pulp-certguard${PULP_CERTGUARD_VERSION} \

--- a/images/pulp-minimal/stable/Containerfile.core
+++ b/images/pulp-minimal/stable/Containerfile.core
@@ -17,9 +17,7 @@ RUN pip install --upgrade \
   pulp-ansible${PULP_ANSIBLE_VERSION} \
   pulp-certguard${PULP_CERTGUARD_VERSION} \
   pulp-container${PULP_CONTAINER_VERSION} \
-  pulp-deb${PULP_DEB_VERSION} \
   pulp-file${PULP_FILE_VERSION} \
-  pulp-maven${PULP_MAVEN_VERSION} \
   pulp-python${PULP_PYTHON_VERSION} \
   pulp-rpm${PULP_RPM_VERSION} \
   pulp-ostree${PULP_OSTREE_VERSION} \

--- a/images/pulp-minimal/stable/Containerfile.core
+++ b/images/pulp-minimal/stable/Containerfile.core
@@ -17,7 +17,9 @@ RUN pip install --upgrade \
   pulp-ansible${PULP_ANSIBLE_VERSION} \
   pulp-certguard${PULP_CERTGUARD_VERSION} \
   pulp-container${PULP_CONTAINER_VERSION} \
+  pulp-deb${PULP_DEB_VERSION} \
   pulp-file${PULP_FILE_VERSION} \
+  pulp-maven${PULP_MAVEN_VERSION} \
   pulp-python${PULP_PYTHON_VERSION} \
   pulp-rpm${PULP_RPM_VERSION} \
   pulp-ostree${PULP_OSTREE_VERSION} \

--- a/images/pulp-minimal/stable/Containerfile.webserver
+++ b/images/pulp-minimal/stable/Containerfile.webserver
@@ -3,9 +3,9 @@ FROM pulp/pulp-minimal:${FROM_TAG} as builder
 
 RUN mkdir -p /etc/nginx/pulp \
              /www/data
-RUN ln $(pip3 show pulp_ansible | sed -n -e 's/Location: //p')/pulp_ansible/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_ansible.conf
-RUN ln $(pip3 show pulp_container | sed -n -e 's/Location: //p')/pulp_container/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_container.conf
-RUN ln $(pip3 show pulp_python | sed -n -e 's/Location: //p')/pulp_python/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_python.conf
+RUN ln $(pip show pulp_ansible | sed -n -e 's/Location: //p')/pulp_ansible/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_ansible.conf
+RUN ln $(pip show pulp_container | sed -n -e 's/Location: //p')/pulp_container/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_container.conf
+RUN ln $(pip show pulp_python | sed -n -e 's/Location: //p')/pulp_python/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_python.conf
 
 
 

--- a/images/pulp/nightly/Containerfile
+++ b/images/pulp/nightly/Containerfile
@@ -1,7 +1,7 @@
 ARG FROM_TAG="latest"
 FROM pulp/pulp-ci-centos9:${FROM_TAG}
 
-RUN pip3 install --upgrade \
+RUN pip install --upgrade \
   git+https://github.com/pulp/pulpcore@main \
   git+https://github.com/pulp/pulp_ansible@main \
   git+https://github.com/pulp/pulp-certguard@main \
@@ -22,6 +22,6 @@ RUN PULP_STATIC_ROOT=/var/lib/operator/static/ PULP_CONTENT_ORIGIN=localhost \
        /usr/local/bin/pulpcore-manager collectstatic --clear --noinput --link
 USER root:root
 
-RUN ln $(pip3 show pulp_ansible | sed -n -e 's/Location: //p')/pulp_ansible/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_ansible.conf
-RUN ln $(pip3 show pulp_container | sed -n -e 's/Location: //p')/pulp_container/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_container.conf
-RUN ln $(pip3 show pulp_python | sed -n -e 's/Location: //p')/pulp_python/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_python.conf
+RUN ln $(pip show pulp_ansible | sed -n -e 's/Location: //p')/pulp_ansible/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_ansible.conf
+RUN ln $(pip show pulp_container | sed -n -e 's/Location: //p')/pulp_container/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_container.conf
+RUN ln $(pip show pulp_python | sed -n -e 's/Location: //p')/pulp_python/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_python.conf

--- a/images/pulp/stable/Containerfile
+++ b/images/pulp/stable/Containerfile
@@ -13,7 +13,7 @@ ARG PULP_PYTHON_VERSION=""
 ARG PULP_RPM_VERSION=""
 ARG PULP_OSTREE_VERSION=""
 
-RUN pip3 install --upgrade \
+RUN pip install --upgrade \
   pulpcore${PULPCORE_VERSION} \
   pulp-ansible${PULP_ANSIBLE_VERSION} \
   pulp-certguard${PULP_CERTGUARD_VERSION} \
@@ -35,6 +35,6 @@ RUN PULP_STATIC_ROOT=/var/lib/operator/static/ PULP_CONTENT_ORIGIN=localhost \
        /usr/local/bin/pulpcore-manager collectstatic --clear --noinput --link
 USER root:root
 
-RUN ln $(pip3 show pulp_ansible | sed -n -e 's/Location: //p')/pulp_ansible/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_ansible.conf
-RUN ln $(pip3 show pulp_container | sed -n -e 's/Location: //p')/pulp_container/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_container.conf
-RUN ln $(pip3 show pulp_python | sed -n -e 's/Location: //p')/pulp_python/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_python.conf
+RUN ln $(pip show pulp_ansible | sed -n -e 's/Location: //p')/pulp_ansible/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_ansible.conf
+RUN ln $(pip show pulp_container | sed -n -e 's/Location: //p')/pulp_container/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_container.conf
+RUN ln $(pip show pulp_python | sed -n -e 's/Location: //p')/pulp_python/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_python.conf

--- a/images/pulp/stable/Containerfile
+++ b/images/pulp/stable/Containerfile
@@ -18,10 +18,7 @@ RUN pip install --upgrade \
   pulp-ansible${PULP_ANSIBLE_VERSION} \
   pulp-certguard${PULP_CERTGUARD_VERSION} \
   pulp-container${PULP_CONTAINER_VERSION} \
-  pulp-deb${PULP_DEB_VERSION} \
   pulp-file${PULP_FILE_VERSION} \
-  pulp-gem${PULP_GEM_VERSION} \
-  pulp-maven${PULP_MAVEN_VERSION} \
   pulp-python${PULP_PYTHON_VERSION} \
   pulp-rpm${PULP_RPM_VERSION} \
   pulp-ostree${PULP_OSTREE_VERSION} \

--- a/images/pulp/stable/Containerfile
+++ b/images/pulp/stable/Containerfile
@@ -18,7 +18,10 @@ RUN pip install --upgrade \
   pulp-ansible${PULP_ANSIBLE_VERSION} \
   pulp-certguard${PULP_CERTGUARD_VERSION} \
   pulp-container${PULP_CONTAINER_VERSION} \
+  pulp-deb${PULP_DEB_VERSION} \
   pulp-file${PULP_FILE_VERSION} \
+  pulp-gem${PULP_GEM_VERSION} \
+  pulp-maven${PULP_MAVEN_VERSION} \
   pulp-python${PULP_PYTHON_VERSION} \
   pulp-rpm${PULP_RPM_VERSION} \
   pulp-ostree${PULP_OSTREE_VERSION} \

--- a/images/pulp_ci_centos/Containerfile
+++ b/images/pulp_ci_centos/Containerfile
@@ -22,13 +22,29 @@ ENV S6_BEHAVIOUR_IF_STAGE2_FAILS=1
 # https://github.com/just-containers/s6-overlay/issues/467
 ENV S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0
 
-RUN dnf -y install postgresql \
-      postgresql-contrib \
-      postgresql-server \
-      postgresql-upgrade \
+RUN dnf -y install "https://download.postgresql.org/pub/repos/yum/reporpms/EL-9-$(arch)/pgdg-redhat-repo-latest.noarch.rpm" && \
+    dnf -qy module disable postgresql && \
+    dnf -y install postgresql16 \
+      postgresql16-server \
+      postgresql16-contrib \
       nginx \
       redis && \
     dnf clean all
+
+RUN alternatives --install /usr/bin/postgres postgres /usr/pgsql-16/bin/postgres 160 \
+      --follower /usr/bin/pg_dump pg_dump /usr/pgsql-16/bin/pg_dump \
+      --follower /usr/bin/pg_dumpall pg_dumpall /usr/pgsql-16/bin/pg_dumpall \
+      --follower /usr/bin/pg_restore pg_restore /usr/pgsql-16/bin/pg_restore \
+      --follower /usr/bin/psql psql /usr/pgsql-16/bin/psql \
+      --follower /usr/bin/createdb createdb /usr/pgsql-16/bin/createdb \
+      --follower /usr/bin/dropdb dropdb /usr/pgsql-16/bin/dropdb \
+      --follower /usr/bin/createuser createuser /usr/pgsql-16/bin/createuser \
+      --follower /usr/bin/dropuser dropuser /usr/pgsql-16/bin/dropuser \
+      --follower /usr/bin/pg_isready pg_isready /usr/pgsql-16/bin/pg_isready \
+      --follower /usr/bin/pg_basebackup pg_basebackup /usr/pgsql-16/bin/pg_basebackup \
+      --follower /usr/bin/pg_ctl pg_ctl /usr/pgsql-16/bin/pg_ctl \
+      --follower /usr/bin/initdb initdb /usr/pgsql-16/bin/initdb \
+      --follower /usr/bin/pg_upgrade pg_upgrade /usr/pgsql-16/bin/pg_upgrade
 
 COPY images/s6_assets/openssl.cnf /etc/ssl/pulp/openssl.cnf
 COPY images/s6_assets/v3.cnf /etc/ssl/pulp/v3.cnf

--- a/images/pulp_debuginfod/Containerfile
+++ b/images/pulp_debuginfod/Containerfile
@@ -20,9 +20,7 @@ RUN pip install --upgrade \
   pulp-ansible${PULP_ANSIBLE_VERSION} \
   pulp-certguard${PULP_CERTGUARD_VERSION} \
   pulp-container${PULP_CONTAINER_VERSION} \
-  pulp-deb${PULP_DEB_VERSION} \
   pulp-file${PULP_FILE_VERSION} \
-  pulp-maven${PULP_MAVEN_VERSION} \
   pulp-python${PULP_PYTHON_VERSION} \
   pulp-rpm${PULP_RPM_VERSION} \
   pulp-ostree${PULP_OSTREE_VERSION} \

--- a/images/pulp_debuginfod/Containerfile
+++ b/images/pulp_debuginfod/Containerfile
@@ -20,7 +20,9 @@ RUN pip install --upgrade \
   pulp-ansible${PULP_ANSIBLE_VERSION} \
   pulp-certguard${PULP_CERTGUARD_VERSION} \
   pulp-container${PULP_CONTAINER_VERSION} \
+  pulp-deb${PULP_DEB_VERSION} \
   pulp-file${PULP_FILE_VERSION} \
+  pulp-maven${PULP_MAVEN_VERSION} \
   pulp-python${PULP_PYTHON_VERSION} \
   pulp-rpm${PULP_RPM_VERSION} \
   pulp-ostree${PULP_OSTREE_VERSION} \

--- a/images/pulp_debuginfod/Containerfile
+++ b/images/pulp_debuginfod/Containerfile
@@ -15,7 +15,7 @@ ARG PULP_CLI_VERSION=""
 # Additional debuginfod arguments such as -d DATABASE or -t SECONDS. See man debuginfod for the full argument list
 ARG DEBUGINFOD_OPTIONS=""
 
-RUN pip3 install --upgrade \
+RUN pip install --upgrade \
   pulpcore${PULPCORE_VERSION} \
   pulp-ansible${PULP_ANSIBLE_VERSION} \
   pulp-certguard${PULP_CERTGUARD_VERSION} \
@@ -30,9 +30,9 @@ RUN pip3 install --upgrade \
   requests && \
   rm -rf /root/.cache/pip
 
-RUN ln /usr/local/lib/python3.9/site-packages/pulp_ansible/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_ansible.conf
-RUN ln /usr/local/lib/python3.9/site-packages/pulp_container/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_container.conf
-RUN ln /usr/local/lib/python3.9/site-packages/pulp_python/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_python.conf
+RUN ln /usr/local/lib/python3.11/site-packages/pulp_ansible/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_ansible.conf
+RUN ln /usr/local/lib/python3.11/site-packages/pulp_container/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_container.conf
+RUN ln /usr/local/lib/python3.11/site-packages/pulp_python/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_python.conf
 
 # Install debuginfod and run as a background process
 RUN dnf -y install elfutils-debuginfod

--- a/images/s6_assets/init/postgres-init
+++ b/images/s6_assets/init/postgres-init
@@ -16,6 +16,7 @@ export C037="\e[37m"
 PGVERSION=$(postgres --version | egrep -o "1[0-9]" | head -n1)
 PGHOME="/var/lib/pgsql"
 PGDATA="${PGHOME}/data"
+PGDATA_NEW="${PGHOME}/data_new"
 PGDATA_OLD="${PGHOME}/data_old"
 PGDATA_OLD_RENAMED="${PGHOME}/data_old.$(date --rfc-3339=seconds)"
 
@@ -24,23 +25,70 @@ if [ -d "${PGDATA}/base" -a -f "${PGDATA}/PG_VERSION" ]; then
   if [ "${PGDATA_VERSION}" != "${PGVERSION}" ]; then
     echo -e "${PREFIX} ${ORANGE} Postgresql database exists but will be upgraded from ${PGDATA_VERSION} to ${PGVERSION}${ENDCOLOR}"
     if [ -d ${PGDATA_OLD} ]; then
-      echo -e "${PREFIX} ${ORANGE} Renaming ${PGDATA_OLD} ${PGDATA_OLD} to ${PGDATA_OLD_RENAMED}${ENDCOLOR}"
-      mv ${PGDATA_OLD} "${PGDATA_OLD_RENAMED}"
+      echo -e "${PREFIX} ${ORANGE} Renaming ${PGDATA_OLD} to ${PGDATA_OLD_RENAMED}${ENDCOLOR}"
+      mv "${PGDATA_OLD}" "${PGDATA_OLD_RENAMED}"
     fi
-
+    # Install the old version of postgresql for pg_upgrade
+    # PostgreSQL 13 is EOL and no longer in standard repos, so we need to add the EOL repository
+    if [ "${PGDATA_VERSION}" = "13" ]; then
+      ARCH=$(uname -m)
+      if [ "${ARCH}" != "x86_64" -a "${ARCH}" != "aarch64" ]; then
+        echo -e "${PREFIX} ${RED}Unsupported architecture ${ARCH} for PostgreSQL 13 EOL repository${ENDCOLOR}"
+        exit 1
+      fi
+      echo -e "${PREFIX} ${ORANGE}PostgreSQL 13 is EOL, adding EOL repository for ${ARCH}${ENDCOLOR}"
+      REPO_FILE="/etc/yum.repos.d/pgdg-13-eol.repo"
+      cat > "${REPO_FILE}" <<EOF
+[pgdg13-eol]
+name=PostgreSQL 13 EOL for RHEL 9 - ${ARCH}
+baseurl=https://yum-archive.postgresql.org/13/redhat/rhel-9-${ARCH}/
+enabled=1
+gpgcheck=1
+gpgkey=https://yum.postgresql.org/keys/PGDG-RPM-GPG-KEY-RHEL
+EOF
+      echo -e "${PREFIX} ${ORANGE}Created repository file ${REPO_FILE}${ENDCOLOR}"
+    fi
+    dnf -y install "postgresql${PGDATA_VERSION}" "postgresql${PGDATA_VERSION}-server" "postgresql${PGDATA_VERSION}-contrib"
     # We have to check the encoding and the locale because pulp/pulp-oci-images #307 (1da694c) means it may differ.
     # In order to check the encoding and the locale, we have to start the postgresql server,
-    # and we have to do so with the v12 binaries from the "postgresql-upgrade" RPM package.
-    # (We only support upgrading from v12 because that's all that the pulp single (s6) container has ever used previously.)
+    # and we have to do so with the old binaries we just installed.
     # This particular command `pg_ctl start` does not block.
-    su postgres -c "/usr/lib64/pgsql/postgresql-12/bin/pg_ctl start -D ${PGDATA}"
-    # The v12 binary listens on a non-standard socket under /tmp. So let's just use localhost (IP) instead.
-    ENCODING=$(su postgres -c "psql --host=localhost postgres -t -c 'SHOW server_encoding' | xargs")
-    LOCALE=$(su postgres -c "psql --host=localhost postgres -t -c 'SHOW lc_collate' | xargs")
-    su postgres -c "/usr/lib64/pgsql/postgresql-12/bin/pg_ctl stop -D ${PGDATA}"
-
-    echo -e "${PREFIX} ${ORANGE}PGSETUP_INITDB_OPTIONS=\"-E ${ENCODING} --locale=${LOCALE} --auth=trust\" postgresql-upgrade ${PGDATA}${ENDCOLOR}"
-    su postgres -c "PGSETUP_INITDB_OPTIONS=\"-E ${ENCODING} --locale=${LOCALE} --auth=trust\" postgresql-upgrade ${PGDATA}" || { echo -e "${PREFIX} ${RED} Failed to upgrade the postgresql database${ENDCOLOR}" ; exit 1; }
+    su postgres -c "/usr/pgsql-${PGDATA_VERSION}/bin/pg_ctl start -D ${PGDATA}"
+    ENCODING=$(psql -U postgres -t -c 'SHOW server_encoding' | xargs)
+    LOCALE=$(psql -U postgres -t -c 'SHOW lc_collate' | xargs)
+    su postgres -c "/usr/pgsql-${PGDATA_VERSION}/bin/pg_ctl stop -D ${PGDATA}"
+    # Initialize the new cluster
+    echo -e "${PREFIX} ${ORANGE}initdb -D ${PGDATA_NEW} -E ${ENCODING} --locale=${LOCALE} --auth=trust${ENDCOLOR}"
+    su postgres -c "initdb -D ${PGDATA_NEW} -E ${ENCODING} --locale=${LOCALE} --auth=trust" || { echo -e "${PREFIX} ${RED} failed to initialize the new database${ENDCOLOR}" ; exit 1; }
+    # Run the upgrade (pg_upgrade needs to have permissions to write in the current directory)
+    cd "${PGHOME}"
+    echo -e "${PREFIX} ${ORANGE}Running pg_upgrade --check${ENDCOLOR}"
+    su postgres -c "pg_upgrade \
+        --old-datadir=${PGDATA} \
+        --new-datadir=${PGDATA_NEW} \
+        --old-bindir=/usr/pgsql-${PGDATA_VERSION}/bin \
+        --new-bindir=/usr/pgsql-${PGVERSION}/bin \
+        --check" \
+      || { echo -e "${PREFIX} ${RED} upgrade check failed${ENDCOLOR}" ; exit 1; }
+    echo -e "${PREFIX} ${ORANGE}Running pg_upgrade${ENDCOLOR}"
+    su postgres -c "pg_upgrade \
+        --old-datadir=${PGDATA} \
+        --new-datadir=${PGDATA_NEW} \
+        --old-bindir=/usr/pgsql-${PGDATA_VERSION}/bin \
+        --new-bindir=/usr/pgsql-${PGVERSION}/bin" \
+      || { echo -e "${PREFIX} ${RED} failed to upgrade the database${ENDCOLOR}" ; exit 1; }
+    # Now swap the data directories
+    echo -e "${PREFIX} ${ORANGE}Moving ${PGDATA} to ${PGDATA_OLD}${ENDCOLOR}"
+    mv "${PGDATA}" "${PGDATA_OLD}"
+    echo -e "${PREFIX} ${ORANGE}Moving ${PGDATA_NEW} to ${PGDATA}${ENDCOLOR}"
+    mv "${PGDATA_NEW}" "${PGDATA}"
+    # Check if there is a update_extensions.sql to run
+    if [ -f "${PGHOME}/update_extensions.sql" ]; then
+      echo -e "${PREFIX} ${ORANGE}Running psql -U postgres -f ${PGHOME}/update_extensions.sql${ENDCOLOR}"
+      su postgres -c "pg_ctl start -D ${PGDATA}"
+      psql -U postgres -f "${PGHOME}/update_extensions.sql" || { echo -e "${PREFIX} ${RED} failed to run update_extensions.sql${ENDCOLOR}" ; exit 1; }
+      su postgres -c "pg_ctl stop -D ${PGDATA}"
+    fi
   fi
 else
   echo -e "${PREFIX} ${GREEN}initdb -E UTF8 --locale=C.UTF-8 --pgdata ${PGDATA}${ENDCOLOR}"

--- a/images/s6_assets/pulp_tests.sh
+++ b/images/s6_assets/pulp_tests.sh
@@ -13,6 +13,8 @@ grep "127.0.0.1   pulp" /etc/hosts || echo "127.0.0.1   pulp" | sudo tee -a /etc
 
 echo "Installing Pulp-CLI"
 pip install pulp-cli
+echo "Installing uv"
+pip install uv
 
 # Retreive installed pulp-cli version
 PULP_CLI_VERSION=$(python3 -c \
@@ -30,7 +32,12 @@ else
   cd pulp-cli
 fi
 
-pip install -r test_requirements.txt || pip install --no-build-isolation -r test_requirements.txt
+# Newer pulp-cli versions (>= 0.39) removed test_requirements.txt and use uv
+# dependency groups instead; `make paralleltest` below calls `uv run` which
+# handles installing test deps automatically.
+if [ -f test_requirements.txt ]; then
+  pip install -r test_requirements.txt || pip install --no-build-isolation -r test_requirements.txt
+fi
 
 if [ -e tests/cli.toml ]; then
   mv tests/cli.toml "tests/cli.toml.bak.$(date -R)"
@@ -58,10 +65,12 @@ echo "Setup ansible signing service"
 podman exec -u pulp -i pulp bash -c "cat > /var/lib/pulp/scripts/sign_detached.sh" < "${PWD}/tests/assets/sign_detached.sh"
 podman exec -u pulp pulp chmod a+rx /var/lib/pulp/scripts/sign_detached.sh
 podman exec -u pulp pulp bash -c "pulpcore-manager add-signing-service --class core:AsciiArmoredDetachedSigningService sign_ansible /var/lib/pulp/scripts/sign_detached.sh 'pulp-fixture-signing-key'"
-echo "Setup deb release signing service"
-podman exec -u pulp -i pulp bash -c "cat > /var/lib/pulp/scripts/sign_deb_release.sh" < "${PWD}/tests/assets/sign_deb_release.sh"
-podman exec -u pulp pulp chmod a+rx /var/lib/pulp/scripts/sign_deb_release.sh
-podman exec -u pulp pulp bash -c "pulpcore-manager add-signing-service --class deb:AptReleaseSigningService sign_deb_release /var/lib/pulp/scripts/sign_deb_release.sh 'pulp-fixture-signing-key'"
+if podman exec -u pulp pulp bash -c "pip show pulp-deb" > /dev/null 2>&1; then
+  echo "Setup deb release signing service"
+  podman exec -u pulp -i pulp bash -c "cat > /var/lib/pulp/scripts/sign_deb_release.sh" < "${PWD}/tests/assets/sign_deb_release.sh"
+  podman exec -u pulp pulp chmod a+rx /var/lib/pulp/scripts/sign_deb_release.sh
+  podman exec -u pulp pulp bash -c "pulpcore-manager add-signing-service --class deb:AptReleaseSigningService sign_deb_release /var/lib/pulp/scripts/sign_deb_release.sh 'pulp-fixture-signing-key'"
+fi
 
 # Test buildah for pulp_container's usage
 podman exec -u pulp pulp podman system migrate

--- a/images/s6_assets/test.sh
+++ b/images/s6_assets/test.sh
@@ -2,8 +2,10 @@
 set -euo pipefail
 
 cleanup() {
-  echo ::group::INFO
-  podman exec pulp bash -c "pip3 list && pip3 install pipdeptree && pipdeptree" || true
+  echo ::group::PIP_LIST
+  podman exec pulp bash -c "pip list && pip install pipdeptree && pipdeptree"
+  echo ::endgroup::
+  echo ::group::PODMAN_LOGS
   podman logs pulp
   echo ::endgroup::
   podman stop pulp
@@ -26,8 +28,10 @@ start_container_and_wait() {
              --device /dev/fuse \
              -e PULP_DEFAULT_ADMIN_PASSWORD=password \
              -e PULP_HTTPS=${pulp_https} \
+             -e PULP_DOMAIN_ENABLED=${domain_enabled} \
              "$1"
-  sleep 10  # Wait for the container to start
+
+  sleep 3  # Wait for the container to start
   podman exec pulp s6-rc -ba list
   for _ in $(seq 30)
   do
@@ -57,6 +61,7 @@ else
   port=443
   pulp_https=true
 fi
+domain_enabled=false
 
 # Configure the GHA host for buildah/skopeo running within the pulp container
 # Default range is 165536-231071, 64K long
@@ -75,10 +80,9 @@ if [ "$old_image" != "" ]; then
   start_container_and_wait $old_image
   podman rm -f pulp
 fi
+if [[ "$image" == "pulp/pulp:ci" ]]; then
+  domain_enabled=true
+fi
 start_container_and_wait $image
 
-if [[ ${image} != *"galaxy"* ]];then
-  source "$BASEDIR/pulp_tests.sh" $scheme
-else
-  source "$BASEDIR/galaxy_ng_tests.sh" $scheme
-fi
+source "$BASEDIR/pulp_tests.sh" $scheme

--- a/images/s6_assets/test.sh
+++ b/images/s6_assets/test.sh
@@ -54,6 +54,7 @@ BASEDIR=$(dirname "$0")
 image=${1:-pulp/pulp:latest}
 scheme=${2:-http}
 old_image=${3:-""}
+app_branch=${4:-latest}
 if [[ "$scheme" == "http" ]]; then
   port=80
   pulp_https=false
@@ -80,7 +81,7 @@ if [ "$old_image" != "" ]; then
   start_container_and_wait $old_image
   podman rm -f pulp
 fi
-if [[ "$image" == "pulp/pulp:ci" ]]; then
+if [[ "$image" == "pulp/pulp:ci" && "$app_branch" == "latest" ]]; then
   domain_enabled=true
 fi
 start_container_and_wait $image


### PR DESCRIPTION
## Summary
- Upgrade base images from Python 3.9 to Python 3.11 with update-alternatives
- Upgrade embedded PostgreSQL from distro packages to PostgreSQL 16 via PGDG
- Replace postgres-init upgrade logic with pg_upgrade flow (including PG13 EOL repo support)
- Update pip3 references and hardcoded python3.9 site-packages paths
- Update CI constraint scripts to reflect Python 3.11 on these images

This backports the runtime upgrades from 3.85 to fix createrepo_c build/runtime
failures on Python 3.9 release branches.

## Test plan
- [ ] CI build-and-test-images passes on amd64 and arm
- [ ] pulp-operator job passes (3.73+)
- [ ] Fresh container starts and passes API status check
- [ ] Existing PG13/14 data directory upgrades cleanly to PG16 on container restart

Made with [Cursor](https://cursor.com)