### PR TITLE
Set Valkey working directory to /var/lib/valkey in CS10 image

### DIFF
--- a/images/pulp_ci_centos/Containerfile.cs10
+++ b/images/pulp_ci_centos/Containerfile.cs10
@@ -35,7 +35,10 @@ RUN ln -s /usr/bin/valkey-server /usr/bin/redis-server && \
     ln -s /etc/valkey/valkey.conf /etc/valkey/redis.conf && \
     useradd -o -u $(id -u valkey) -g $(id -g valkey) -M -N redis || true && \
     install -d -m 0755 -o valkey -g valkey /run/valkey && \
-    install -d -m 0750 -o valkey -g valkey /var/log/valkey
+    install -d -m 0750 -o valkey -g valkey /var/log/valkey && \
+    # Valkey defaults to writing dump files to ./ which fails if cwd is not writable
+    install -d -m 0750 -o valkey -g valkey /var/lib/valkey && \
+    sed -i 's|^[# ]*dir .*|dir /var/lib/valkey|' /etc/valkey/valkey.conf
 
 RUN alternatives --install /usr/bin/postgres postgres /usr/pgsql-16/bin/postgres 160 \
       --follower /usr/bin/pg_dump pg_dump /usr/pgsql-16/bin/pg_dump \


### PR DESCRIPTION
Valkey defaults to writing dump files to the current working directory, which causes permission errors when cwd is not writable (e.g, when running through s6 supervisor, which runs from the s6 service dir).

This was causing pulp rpm CI to fail, as it's using Centos10, which handles valkey differently than CS9. Here is a investigating PR: https://github.com/pulp/pulp_rpm/pull/4505


---

## Affected images

| Tag | Built | Status |
|-----|-------|--------|
| `3.113.0` | 2026-06-08 | OK |
| `3.114.0` | 2026-07-14 | Broken |

Image `3.114.0` includes commit `5ec1cb43` which creates `/run/valkey`, allowing
valkey to bind its unix socket and run stably. Image `3.113.0` lacks this
directory, so valkey never fully starts.

## Root cause

Valkey's default config sets `dir ./` (line 612 of `valkey.conf`), meaning RDB
snapshots are written to the current working directory. s6-supervise sets cwd to
the service directory (`/run/s6-rc:.../servicedirs/redis/`), owned by root.

During boot, the `add-workers` init script runs `s6-rc-update`, which sends
SIGTERM to valkey. Valkey attempts an RDB save before exiting:

```
# Failed opening the temp RDB file temp-92.rdb
#   (in server root dir /run/s6-rc:s6-rc-init:.../servicedirs/redis)
#   for saving: Permission denied
# Error trying to save the DB, can't exit.
```

s6-rc-update hangs waiting for valkey. PostgreSQL was already stopped as part of
the transition and never restarts. Pulp never starts.

## Evidence

1. `docker exec <container> cat /var/log/valkey/valkey.log` shows the
   "Permission denied" / "can't exit" messages above.
2. `docker exec <container> ps aux | grep s6-rc-update` shows the process stuck.
3. `docker exec <container> pg_isready -U postgres` returns "no response".
4. Patching valkey config with `dir /tmp` makes SIGTERM shutdown succeed
   immediately, PG restarts, Pulp boots.

## Fix

Pass `--dir <writable-path>` to valkey at startup. CLI args override the config
file's `dir ./`. The s6 run script or a `VALKEY_EXTRA_FLAGS` env var are both
viable delivery mechanisms.

## Reproducing

```bash
# start all three
docker run -d --name test ghcr.io/pulp/pulp-ci-centos10:3.114.0
docker run -d --name patched ghcr.io/pulp/pulp-ci-centos10:3.114.0
docker exec patched sed -i 's|^dir \./|dir /tmp|' /etc/valkey/valkey.conf
docker restart patched
docker run -d --name control ghcr.io/pulp/pulp-ci-centos10:3.113.0

sleep 30

# assert
echo "== Broken =="
docker exec test pg_isready -U postgres          # no response
docker exec test cat /var/log/valkey/valkey.log | tail

echo "== Patched =="
docker exec patched pg_isready -U postgres       # accepting connections

echo "== Control =="
docker exec control pg_isready -U postgres       # accepting connections
```
