### PR TITLE
Update CI files to reflect new upgrades in old images

### DIFF
--- a/.ci/scripts/get_supported_specifiers.py
+++ b/.ci/scripts/get_supported_specifiers.py
@@ -33,8 +33,8 @@ PACKAGES = [
 ]
 
 PYTHON_VERSIONS = {
-    Requirement("pulpcore>=3.22,<3.85"): "3.9",
-    Requirement("pulpcore>=3.85"): "3.11"
+    Requirement("pulpcore>=3.22,<3.49"): "3.9",
+    Requirement("pulpcore>=3.49"): "3.11"
 }
 
 

--- a/images/s6_assets/test.sh
+++ b/images/s6_assets/test.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 cleanup() {
   echo ::group::PIP_LIST
-  podman exec pulp bash -c "pip list && pip install pipdeptree && pipdeptree"
+  podman exec pulp bash -c "pip list && pip install pipdeptree<4 && pipdeptree" || true
   echo ::endgroup::
   echo ::group::PODMAN_LOGS
   podman logs pulp


### PR DESCRIPTION
3.49, 3.63, and 3.73 are all being upgraded to python 3.11, so update our helper scripts to make sure it knows what versions are available to install.