### PR TITLE
Add SECRET_KEY to test settings to fix CI

### DIFF
--- a/images/s6_assets/test.sh
+++ b/images/s6_assets/test.sh
@@ -70,6 +70,7 @@ sudo sed -i "s\runner:165536:65536\runner:165536:75536\g" /etc/subuid /etc/subgi
 podman system migrate
 
 mkdir -p settings pulp_storage pgsql containers
+echo "SECRET_KEY = 'aabbcc'" >> settings/settings.py
 echo "CONTENT_ORIGIN='$scheme://localhost:8080'" >> settings/settings.py
 echo "ALLOWED_EXPORT_PATHS = ['/tmp']" >> settings/settings.py
 echo "ANALYTICS = False" >> settings/settings.py


### PR DESCRIPTION
Pulpcore removed the insecure default SECRET_KEY from its settings, so it must be set explicitly.