### PR TITLE
Remove obsolete rhsm package from image extras

### DIFF
--- a/images/assets/requirements.extra.txt
+++ b/images/assets/requirements.extra.txt
@@ -1,4 +1,3 @@
-rhsm
 django-auth-ldap
 python-json-logger
 social-auth-core


### PR DESCRIPTION
## Summary
- Drop the unmaintained PyPI `rhsm` package from `requirements.extra.txt`.
- Pulpcore replaced `python-rhsm` with a local RHSMCertGuard implementation; the old package fails to build on CentOS Stream 10 / GCC 14 and broke the nightly image build.

## Test plan
- [ ] Confirm nightly `pulp` image build on CS10 succeeds without compiling `rhsm`
- [ ] Confirm RHSMCertGuard functional coverage still passes (uses pulpcore's local implementation)


Made with [Cursor](https://cursor.com)