### PR TITLE
Increase nginx header buffer size for PQC certificates

### DIFF
--- a/images/s6_assets/nginx.conf.j2
+++ b/images/s6_assets/nginx.conf.j2
@@ -20,6 +20,10 @@ http {
     # to build optimal hash types.
     types_hash_max_size 4096;
 
+    # PQC (post-quantum) X.509 certificates can exceed the default 8k buffer
+    # when forwarded as HTTP headers (e.g. X-CLIENT-CERT).
+    large_client_header_buffers 4 16k;
+
     upstream pulp-content {
          server {{ '[::1]' if has_ipv6 else '127.0.0.1' }}:24816;
     }


### PR DESCRIPTION
Post-quantum (ML-DSA) X.509 certificates are significantly larger than traditional RSA/ECDSA certificates. When a reverse proxy forwards a PQC client certificate via the X-CLIENT-CERT header, it can exceed nginx's default large_client_header_buffers size (4x8k), causing a 400 error before the request reaches the content app. Increase to 4x16k.

Assisted-By: Claude Opus 4.6