### PR TITLE
[PR #842/40a90890 backport][3.105] Fix several CI issues

### DIFF
--- a/.github/actions/build_image/action.yml
+++ b/.github/actions/build_image/action.yml
@@ -88,7 +88,7 @@ runs:
         if [[ "${{ inputs.image_name }}" == "pulp-minimal" ]]; then
           base_image=$(echo ${{ inputs.image_name }} | cut -d '-' -f1)
           podman build --format docker --pull=false --file images/${{ inputs.image_name }}/${{ inputs.image_variant }}/Containerfile.core --tag pulp/${{ inputs.image_name }}:ci --build-arg FROM_TAG=ci .
-          podman build --format docker --pull=false --file images/${{ inputs.image_name }}/${{ inputs.image_variant }}/Containerfile.webserver --tag pulp/${base_image}-web:ci --build-arg FROM_TAG=ci .
+          podman build --format docker --pull=missing --file images/${{ inputs.image_name }}/${{ inputs.image_variant }}/Containerfile.webserver --tag pulp/${base_image}-web:ci --build-arg FROM_TAG=ci .
         else
           podman build --format docker --pull=false --file images/${{ inputs.image_name }}/${{ inputs.image_variant }}/Containerfile --tag pulp/${{ inputs.image_name }}:ci --build-arg FROM_TAG=ci ${{ env.BUILD_UI_ARG }} .
         fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,9 +156,22 @@ jobs:
           echo "INFO:
           Updating registries configuration
           "
-          echo "[registries.insecure]
-          registries = ['ingress.local','nodeport.local:30000']
-          " | sudo tee -a /etc/containers/registries.conf
+          # registries.conf v1 and v2 formats cannot be mixed in the same file;
+          # detect which format the runner uses and append matching syntax.
+          if grep -q "unqualified-search-registries" /etc/containers/registries.conf; then
+            echo '
+          [[registry]]
+          location = "ingress.local"
+          insecure = true
+
+          [[registry]]
+          location = "nodeport.local:30000"
+          insecure = true' | sed 's/^ *//' | sudo tee -a /etc/containers/registries.conf
+          else
+            echo '
+          [registries.insecure]
+          registries = ["ingress.local","nodeport.local:30000"]' | sed 's/^ *//' | sudo tee -a /etc/containers/registries.conf
+          fi
         fi
       shell: bash
 

--- a/images/s6_assets/test.sh
+++ b/images/s6_assets/test.sh
@@ -19,7 +19,7 @@ trap cleanup EXIT
 
 start_container_and_wait() {
   podman run --detach \
-             --publish 8080:$port \
+             --publish 127.0.0.1:8080:$port \
              --name pulp \
              --volume "$(pwd)/settings":/etc/pulp:Z \
              --volume "$(pwd)/pulp_storage":/var/lib/pulp:Z \


### PR DESCRIPTION
**This is a backport of PR #842 as merged into latest (40a9089054fe0e9aa4ae40afb94d9513f0d0235a).**

Cherry-pick conflict: 3.105 does not have the `setup-go@v6` step that was already present on `latest`, so that step was not added.

## Summary
- Use `--pull=missing` when building the pulp-web image so the local pulp-minimal:ci is reused
- Append insecure registries in the format the runner actually uses
- Workaround pulp-operator test script until pulp-operator#1667 lands
- Bind the test container to 127.0.0.1:8080

## Test plan
- [ ] CI build-and-test-images passes
- [ ] pulp-operator job passes

Made with [Cursor](https://cursor.com)