### PR TITLE
[PR #842/40a90890 backport][3.63] Fix several CI issues

### DIFF
--- a/.github/actions/build_image/action.yml
+++ b/.github/actions/build_image/action.yml
@@ -88,7 +88,7 @@ runs:
         if [[ "${{ inputs.image_name }}" == "pulp-minimal" ]]; then
           base_image=$(echo ${{ inputs.image_name }} | cut -d '-' -f1)
           podman build --format docker --pull=false --file images/${{ inputs.image_name }}/${{ inputs.image_variant }}/Containerfile.core --tag pulp/${{ inputs.image_name }}:ci --build-arg FROM_TAG=ci .
-          podman build --format docker --pull=false --file images/${{ inputs.image_name }}/${{ inputs.image_variant }}/Containerfile.webserver --tag pulp/${base_image}-web:ci --build-arg FROM_TAG=ci .
+          podman build --format docker --pull=missing --file images/${{ inputs.image_name }}/${{ inputs.image_variant }}/Containerfile.webserver --tag pulp/${base_image}-web:ci --build-arg FROM_TAG=ci .
         else
           podman build --format docker --pull=false --file images/${{ inputs.image_name }}/${{ inputs.image_variant }}/Containerfile --tag pulp/${{ inputs.image_name }}:ci --build-arg FROM_TAG=ci ${{ env.BUILD_UI_ARG }} .
         fi

--- a/images/s6_assets/test.sh
+++ b/images/s6_assets/test.sh
@@ -19,7 +19,7 @@ trap cleanup EXIT
 
 start_container_and_wait() {
   podman run --detach \
-             --publish 8080:$port \
+             --publish 127.0.0.1:8080:$port \
              --name pulp \
              --volume "$(pwd)/settings":/etc/pulp:Z \
              --volume "$(pwd)/pulp_storage":/var/lib/pulp:Z \


### PR DESCRIPTION
**This is a backport of PR #842 as merged into latest (40a9089054fe0e9aa4ae40afb94d9513f0d0235a).**

Cherry-pick conflict: 3.63 has no pulp-operator CI job, so the registries.conf and operator test-script changes were omitted.

## Summary
- Use `--pull=missing` when building the pulp-web image so the local pulp-minimal:ci is reused
- Bind the test container to 127.0.0.1:8080

## Test plan
- [ ] CI build-and-test-images passes

Made with [Cursor](https://cursor.com)