### PR TITLE
Remove pulp-ostree

### DIFF
--- a/.ci/scripts/check_up_to_date.py
+++ b/.ci/scripts/check_up_to_date.py
@@ -13,7 +13,6 @@ PACKAGES = [
     "pulp-hugging-face",
     "pulp-maven",
     "pulp-npm",
-    "pulp-ostree",
     "pulp-python",
     "pulp-rpm",
 ]

--- a/.ci/scripts/get_supported_specifiers.py
+++ b/.ci/scripts/get_supported_specifiers.py
@@ -27,7 +27,6 @@ PACKAGES = [
     "pulp-hugging-face",
     "pulp-maven",
     "pulp-npm",
-    "pulp-ostree",
     "pulp-python",
     "pulp-rpm",
 ]

--- a/CHANGES/+ostree.removal
+++ b/CHANGES/+ostree.removal
@@ -1,0 +1,1 @@
+Remove pulp-ostree from the images

--- a/docs/admin/reference/available-images/multi-process-images.md
+++ b/docs/admin/reference/available-images/multi-process-images.md
@@ -28,7 +28,6 @@ This image contains [Pulp](https://github.com/pulp/pulpcore) and the following p
 - [pulp_maven](site:pulp_maven)
 - [pulp_python](site:pulp_python)
 - [pulp_rpm](site:pulp_rpm)
-- [pulp_ostree](site:pulp_ostree)
 
 This image can also function the same as the single-process image `pulp-minimal`.
 See the [Single-Process Images](../single-process-images/) page for usage.

--- a/docs/admin/reference/available-images/single-process-images.md
+++ b/docs/admin/reference/available-images/single-process-images.md
@@ -26,7 +26,6 @@ pulp-minimal is currently built with the following plugins:
 - [pulp_maven](site:pulp_maven)
 - [pulp_python](site:pulp_python)
 - [pulp_rpm](site:pulp_rpm)
-- [pulp_ostree](site:pulp_ostree)
 
 ### Tags
 

--- a/images/Containerfile.core.base
+++ b/images/Containerfile.core.base
@@ -47,6 +47,7 @@ RUN dnf -y install python3 python3-pip python3-devel && \
     dnf -y install which && \
     dnf -y install rpm-sign && \
     dnf -y install lsof && \
+    dnf -y install xz && \
     getcap /usr/bin/newuidmap  | grep cap_setuid || dnf -y reinstall -y shadow-utils && \
     dnf clean all
 

--- a/images/Containerfile.core.base
+++ b/images/Containerfile.core.base
@@ -32,7 +32,6 @@ RUN dnf -y install dnf-plugins-core && \
 
 # glibc-langpack-en is needed to provide the en_US.UTF-8 locale, which Pulp
 # seems to need.
-# cairo/gobject are needed for PyGObject, which pulp_ostree requires
 RUN dnf -y install python3 python3-pip python3-devel && \
     dnf -y install openssl openssl-devel && \
     dnf -y install openldap-devel --exclude selinux* && \
@@ -40,8 +39,6 @@ RUN dnf -y install python3 python3-pip python3-devel && \
     dnf -y install gcc libffi-devel && \
     dnf -y install glibc-langpack-en && \
     dnf -y install podman fuse-overlayfs buildah --exclude container-selinux && \
-    dnf -y install cairo-devel gobject-introspection-devel cairo-gobject-devel && \
-    dnf -y install ostree-libs ostree && \
     dnf -y install sequoia-sq && \
     dnf -y install skopeo && \
     dnf -y install sudo && \

--- a/images/pulp-minimal/nightly/Containerfile.core
+++ b/images/pulp-minimal/nightly/Containerfile.core
@@ -12,7 +12,6 @@ RUN uv pip install \
   git+https://github.com/pulp/pulp_deb.git \
   git+https://github.com/pulp/pulp_gem.git \
   git+https://github.com/pulp/pulp_maven.git \
-  git+https://github.com/pulp/pulp_ostree.git \
   git+https://github.com/pulp/pulp_python.git \
   git+https://github.com/pulp/pulp_rpm.git \
   git+https://github.com/pulp/pulp_rust.git \

--- a/images/pulp-minimal/stable/Containerfile.core
+++ b/images/pulp-minimal/stable/Containerfile.core
@@ -11,7 +11,6 @@ ARG PULP_FILE_VERSION=""
 ARG PULP_MAVEN_VERSION=""
 ARG PULP_PYTHON_VERSION=""
 ARG PULP_RPM_VERSION=""
-ARG PULP_OSTREE_VERSION=""
 ARG PULP_NPM_VERSION=""
 ARG PULP_HUGGING_FACE_VERSION=""
 
@@ -29,7 +28,6 @@ RUN uv pip install --upgrade \
   pulp-maven${PULP_MAVEN_VERSION} \
   pulp-python${PULP_PYTHON_VERSION} \
   pulp-rpm${PULP_RPM_VERSION} \
-  pulp-ostree${PULP_OSTREE_VERSION} \
   pulp-npm${PULP_NPM_VERSION} \
   pulp-hugging-face${PULP_HUGGING_FACE_VERSION} \
   -r /requirements.extra.txt \

--- a/images/pulp/nightly/Containerfile
+++ b/images/pulp/nightly/Containerfile
@@ -11,7 +11,6 @@ RUN uv pip install --upgrade \
   git+https://github.com/pulp/pulp_deb@main \
   git+https://github.com/pulp/pulp_gem@main \
   git+https://github.com/pulp/pulp_maven@main \
-  git+https://github.com/pulp/pulp_ostree@main \
   git+https://github.com/pulp/pulp_python@main \
   git+https://github.com/pulp/pulp_rpm@main \
   git+https://github.com/pulp/pulp_rust@main \

--- a/images/pulp/stable/Containerfile
+++ b/images/pulp/stable/Containerfile
@@ -12,7 +12,6 @@ ARG PULP_GEM_VERSION=""
 ARG PULP_MAVEN_VERSION=""
 ARG PULP_PYTHON_VERSION=""
 ARG PULP_RPM_VERSION=""
-ARG PULP_OSTREE_VERSION=""
 ARG PULP_UI_URL=""
 ARG PULP_NPM_VERSION=""
 ARG PULP_HUGGING_FACE_VERSION=""
@@ -31,7 +30,6 @@ RUN uv pip install --upgrade \
   pulp-maven${PULP_MAVEN_VERSION} \
   pulp-python${PULP_PYTHON_VERSION} \
   pulp-rpm${PULP_RPM_VERSION} \
-  pulp-ostree${PULP_OSTREE_VERSION} \
   pulp-npm${PULP_NPM_VERSION} \
   pulp-hugging-face${PULP_HUGGING_FACE_VERSION} \
   -r /requirements.extra.txt \

--- a/images/pulp_debuginfod/Containerfile
+++ b/images/pulp_debuginfod/Containerfile
@@ -10,7 +10,6 @@ ARG PULP_FILE_VERSION=""
 ARG PULP_MAVEN_VERSION=""
 ARG PULP_PYTHON_VERSION=""
 ARG PULP_RPM_VERSION=""
-ARG PULP_OSTREE_VERSION=""
 ARG PULP_NPM_VERSION=""
 ARG PULP_CLI_VERSION=""
 # Additional debuginfod arguments such as -d DATABASE or -t SECONDS. See man debuginfod for the full argument list
@@ -26,7 +25,6 @@ RUN uv pip install --upgrade \
   pulp-maven${PULP_MAVEN_VERSION} \
   pulp-python${PULP_PYTHON_VERSION} \
   pulp-rpm${PULP_RPM_VERSION} \
-  pulp-ostree${PULP_OSTREE_VERSION} \
   pulp-npm${PULP_NPM_VERSION} \
   pulp-cli${PULP_CLI_VERSION} \
   requests && \


### PR DESCRIPTION
pulp-ostree is now archived, no longer install on future releases.